### PR TITLE
Add Storage trait for PbftState

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,19 @@ assets = [
 ]
 maintainer-scripts = "packaging/ubuntu"
 
+[features]
+default = ["with-serde"]
+with-serde = []
+
 [dependencies]
+atomicwrites = "0.2"
 sawtooth_sdk = { git = "https://github.com/hyperledger/sawtooth-core.git", branch = "master" }
-serde_json = "1"
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
+serde_millis = "0.1"
 hex = "0.3"
-protobuf = "2"
+protobuf = { version = "2", features = ["with-serde"] }
 clap = "2.31"
 log = "0.4"
 log4rs = "0.8"
@@ -44,6 +52,7 @@ log4rs = { git = "https://github.com/ltseeley/log4rs", branch = "config-loading"
 
 [dev-dependencies]
 rust-crypto = "0.2"
+rand = "0.5"
 
 [build-dependencies]
 protoc-rust = "2"

--- a/build.rs
+++ b/build.rs
@@ -36,7 +36,10 @@ fn main() {
         out_dir: &dest_path.to_str().unwrap(),
         input: &[proto_path.join("pbft_message.proto").to_str().unwrap()],
         includes: &[proto_path.to_str().unwrap()],
-        customize: Customize::default(),
+        customize: Customize {
+            serde_derive: Some(true),
+            ..Default::default()
+        },
     }).expect("Protoc Error");
 
     // Create mod.rs accordingly

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,9 @@ pub struct PbftConfig {
 
     /// How large the PbftLog is allowed to get
     pub max_log_size: u64,
+
+    /// Where to store PbftState
+    pub storage: String,
 }
 
 impl PbftConfig {
@@ -62,6 +65,7 @@ impl PbftConfig {
             view_change_timeout: Duration::from_millis(4000),
             checkpoint_period: 100,
             max_log_size: 1000,
+            storage: "memory".into(),
         }
     }
 }
@@ -75,6 +79,7 @@ impl PbftConfig {
 /// + `sawtooth.consensus.pbft.view_change_timeout` (optional, default 4000 ms)
 /// + `sawtooth.consensus.pbft.message_timeout` (optional, default 100 blocks)
 /// + `sawtooth.consensus.pbft.max_log_size` (optional, default 1000 messages)
+/// + `sawtooth.consensus.pbft.storage` (optional, default `"memory"`)
 ///
 /// # Panics
 /// + If the `sawtooth.consensus.pbft.peers` setting is not provided

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,11 @@ extern crate log4rs;
 extern crate log4rs_syslog;
 extern crate protobuf;
 extern crate sawtooth_sdk;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_json;
+extern crate serde_millis;
 
 use std::process;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@
 
 #![allow(unknown_lints)]
 
+extern crate atomicwrites;
 #[macro_use]
 extern crate clap;
 #[cfg(test)]
@@ -56,6 +57,7 @@ pub mod message_type;
 pub mod node;
 mod protos;
 pub mod state;
+pub mod storage;
 pub mod timing;
 
 fn main() {

--- a/src/node.rs
+++ b/src/node.rs
@@ -44,9 +44,6 @@ pub struct PbftNode {
     /// Used for interactions with the validator
     pub service: Box<Service>,
 
-    /// Storage of state information
-    pub state: PbftState,
-
     /// Messages this node has received
     pub msg_log: PbftLog,
 }
@@ -54,24 +51,19 @@ pub struct PbftNode {
 impl PbftNode {
     /// Construct a new PBFT node.
     /// After the node is created, if the node is primary, it initializes a new block on the chain.
-    pub fn new(id: u64, config: &PbftConfig, service: Box<Service>) -> Self {
+    pub fn new(config: &PbftConfig, service: Box<Service>, is_primary: bool) -> Self {
         let mut n = PbftNode {
-            state: PbftState::new(id, config),
             service,
             msg_log: PbftLog::new(config),
         };
 
-        Self::initialize_block_if_primary(&mut n);
-        n
-    }
-
-    fn initialize_block_if_primary(node: &mut PbftNode) {
-        if node.state.is_primary() {
-            debug!("{}: Initializing block", node.state);
-            node.service
+        // Primary initializes a block
+        if is_primary {
+            n.service
                 .initialize_block(None)
                 .unwrap_or_else(|err| error!("Couldn't initialize block: {}", err));
         }
+        n
     }
 
     // ---------- Methods for handling Updates from the validator ----------
@@ -85,11 +77,12 @@ impl PbftNode {
         &mut self,
         msg: &PeerMessage,
         sender_id: &PeerId,
+        state: &mut PbftState,
     ) -> Result<(), PbftError> {
         let msg_type = PbftMessageType::from(msg.message_type.as_str());
 
         // Handle a multicast protocol message
-        let multicast_hint = extract_multicast_hint(&self.state, &msg_type, msg)?;
+        let multicast_hint = extract_multicast_hint(state, &msg_type, msg)?;
 
         match msg_type {
             PbftMessageType::PrePrepare => {
@@ -103,7 +96,7 @@ impl PbftNode {
                     return Ok(());
                 }
 
-                if !ignore_hint_pre_prepare(&self.state, &pbft_message) {
+                if !ignore_hint_pre_prepare(state, &pbft_message) {
                     handlers::action_from_hint(
                         &mut self.msg_log,
                         &multicast_hint,
@@ -113,14 +106,14 @@ impl PbftNode {
                     )?;
                 }
 
-                handlers::pre_prepare(&mut self.state, &mut self.msg_log, &pbft_message)?;
+                handlers::pre_prepare(state, &mut self.msg_log, &pbft_message)?;
 
                 // NOTE: Putting log add here is necessary because on_peer_message gets
                 // called again inside of _broadcast_pbft_message
                 self.msg_log.add_message(pbft_message.clone());
-                self.state.switch_phase(PbftPhase::Preparing);
+                state.switch_phase(PbftPhase::Preparing);
 
-                self.broadcast_pre_prepare(&pbft_message)?;
+                self.broadcast_pre_prepare(&pbft_message, state)?;
             }
 
             PbftMessageType::Prepare => {
@@ -144,9 +137,9 @@ impl PbftNode {
 
                 self.msg_log.add_message(pbft_message.clone());
 
-                self.msg_log.prepared(&pbft_message, self.state.f)?;
+                self.msg_log.prepared(&pbft_message, state.f)?;
 
-                self.check_blocks_if_not_checking(&pbft_message)?;
+                self.check_blocks_if_not_checking(&pbft_message, state)?;
             }
 
             PbftMessageType::Commit => {
@@ -170,9 +163,9 @@ impl PbftNode {
 
                 self.msg_log.add_message(pbft_message.clone());
 
-                self.msg_log.committed(&pbft_message, self.state.f)?;
+                self.msg_log.committed(&pbft_message, state.f)?;
 
-                self.commit_block_if_committing(msg, &pbft_message, &sender_id)?;
+                self.commit_block_if_committing(msg, &pbft_message, &sender_id, state)?;
             }
 
             PbftMessageType::Checkpoint => {
@@ -186,22 +179,22 @@ impl PbftNode {
                     return Ok(());
                 }
 
-                if self.check_if_stale_checkpoint(&pbft_message)? {
+                if self.check_if_stale_checkpoint(&pbft_message, state)? {
                     return Ok(());
                 }
 
-                if !self.check_if_checkpoint_started(msg, sender_id) {
+                if !self.check_if_checkpoint_started(msg, sender_id, state) {
                     return Ok(());
                 }
 
                 // Add message to the log
                 self.msg_log.add_message(pbft_message.clone());
 
-                if check_if_secondary(&self.state) {
-                    self.start_checkpointing_and_forward(&pbft_message)?;
+                if check_if_secondary(state) {
+                    self.start_checkpointing_and_forward(&pbft_message, state)?;
                 }
 
-                self.garbage_collect_if_stable_checkpoint(&pbft_message)?;
+                self.garbage_collect_if_stable_checkpoint(&pbft_message, state)?;
             }
 
             PbftMessageType::ViewChange => {
@@ -217,25 +210,19 @@ impl PbftNode {
 
                 debug!(
                     "{}: Received ViewChange message from Node {:02} (v {}, seq {})",
-                    self.state,
-                    self.state
-                        .get_node_id_from_bytes(vc_message.get_info().get_signer_id())?,
+                    state,
+                    state.get_node_id_from_bytes(vc_message.get_info().get_signer_id())?,
                     vc_message.get_info().get_view(),
                     vc_message.get_info().get_seq_num(),
                 );
 
                 self.msg_log.add_view_change(vc_message.clone());
 
-                if self.start_view_change_if_enough_messages(&vc_message)? {
+                if self.start_view_change_if_enough_messages(&vc_message, state)? {
                     return Ok(());
                 }
 
-                handlers::view_change(
-                    &mut self.state,
-                    &mut self.msg_log,
-                    &mut *self.service,
-                    &vc_message,
-                )?;
+                handlers::view_change(state, &mut self.msg_log, &mut *self.service, &vc_message)?;
             }
 
             _ => warn!("Message type not implemented"),
@@ -243,10 +230,14 @@ impl PbftNode {
         Ok(())
     }
 
-    fn broadcast_pre_prepare(&mut self, pbft_message: &PbftMessage) -> Result<(), PbftError> {
+    fn broadcast_pre_prepare(
+        &mut self,
+        pbft_message: &PbftMessage,
+        state: &mut PbftState,
+    ) -> Result<(), PbftError> {
         info!(
             "{}: PrePrepare, sequence number {}",
-            self.state,
+            state,
             pbft_message.get_info().get_seq_num()
         );
 
@@ -254,16 +245,18 @@ impl PbftNode {
             pbft_message.get_info().get_seq_num(),
             &PbftMessageType::Prepare,
             (*pbft_message.get_block()).clone(),
+            state,
         )
     }
 
     fn check_blocks_if_not_checking(
         &mut self,
         pbft_message: &PbftMessage,
+        state: &mut PbftState,
     ) -> Result<(), PbftError> {
-        if self.state.phase != PbftPhase::Checking {
-            self.state.switch_phase(PbftPhase::Checking);
-            debug!("{}: Checking blocks", self.state);
+        if state.phase != PbftPhase::Checking {
+            state.switch_phase(PbftPhase::Checking);
+            debug!("{}: Checking blocks", state);
             self.service
                 .check_blocks(vec![pbft_message.get_block().clone().block_id])
                 .map_err(|_| PbftError::InternalError(String::from("Failed to check blocks")))?
@@ -277,10 +270,11 @@ impl PbftNode {
         msg: &PeerMessage,
         pbft_message: &PbftMessage,
         sender_id: &PeerId,
+        state: &mut PbftState,
     ) -> Result<(), PbftError> {
-        if self.state.phase == PbftPhase::Committing {
+        if state.phase == PbftPhase::Committing {
             handlers::commit(
-                &mut self.state,
+                state,
                 &mut self.msg_log,
                 &mut *self.service,
                 &pbft_message,
@@ -290,25 +284,28 @@ impl PbftNode {
         } else {
             debug!(
                 "{}: Already committed block {:?}",
-                self.state,
+                state,
                 pbft_message.get_block().block_id
             );
             Ok(())
         }
     }
 
-    fn check_if_stale_checkpoint(&mut self, pbft_message: &PbftMessage) -> Result<bool, PbftError> {
+    fn check_if_stale_checkpoint(
+        &mut self,
+        pbft_message: &PbftMessage,
+        state: &mut PbftState,
+    ) -> Result<bool, PbftError> {
         debug!(
             "{}: Received Checkpoint message from {:02}",
-            self.state,
-            self.state
-                .get_node_id_from_bytes(pbft_message.get_info().get_signer_id())?
+            state,
+            state.get_node_id_from_bytes(pbft_message.get_info().get_signer_id())?
         );
 
         if self.msg_log.get_latest_checkpoint() >= pbft_message.get_info().get_seq_num() {
             debug!(
                 "{}: Already at a stable checkpoint with this sequence number or past it!",
-                self.state
+                state
             );
             Ok(true)
         } else {
@@ -317,14 +314,16 @@ impl PbftNode {
     }
 
     #[allow(ptr_arg)]
-    fn check_if_checkpoint_started(&mut self, msg: &PeerMessage, sender_id: &PeerId) -> bool {
+    fn check_if_checkpoint_started(
+        &mut self,
+        msg: &PeerMessage,
+        sender_id: &PeerId,
+        state: &mut PbftState,
+    ) -> bool {
         // Not ready to receive checkpoint yet; only acceptable in NotStarted
-        if self.state.phase != PbftPhase::NotStarted {
+        if state.phase != PbftPhase::NotStarted {
             self.msg_log.push_backlog(msg.clone(), sender_id.clone());
-            debug!(
-                "{}: Not in NotStarted; not handling checkpoint yet",
-                self.state
-            );
+            debug!("{}: Not in NotStarted; not handling checkpoint yet", state);
             false
         } else {
             true
@@ -334,26 +333,29 @@ impl PbftNode {
     fn start_checkpointing_and_forward(
         &mut self,
         pbft_message: &PbftMessage,
+        state: &mut PbftState,
     ) -> Result<(), PbftError> {
-        self.state.pre_checkpoint_mode = self.state.mode;
-        self.state.mode = PbftMode::Checkpointing;
+        state.pre_checkpoint_mode = state.mode;
+        state.mode = PbftMode::Checkpointing;
         self._broadcast_pbft_message(
             pbft_message.get_info().get_seq_num(),
             &PbftMessageType::Checkpoint,
             PbftBlock::new(),
+            state,
         )
     }
 
     fn garbage_collect_if_stable_checkpoint(
         &mut self,
         pbft_message: &PbftMessage,
+        state: &mut PbftState,
     ) -> Result<(), PbftError> {
-        if self.state.mode == PbftMode::Checkpointing {
+        if state.mode == PbftMode::Checkpointing {
             self.msg_log
-                .check_msg_against_log(&pbft_message, true, 2 * self.state.f + 1)?;
+                .check_msg_against_log(&pbft_message, true, 2 * state.f + 1)?;
             warn!(
                 "{}: Reached stable checkpoint (seq num {}); garbage collecting logs",
-                self.state,
+                state,
                 pbft_message.get_info().get_seq_num()
             );
             self.msg_log.garbage_collect(
@@ -361,7 +363,7 @@ impl PbftNode {
                 pbft_message.get_info().get_view(),
             );
 
-            self.state.mode = self.state.pre_checkpoint_mode;
+            state.mode = state.pre_checkpoint_mode;
         }
         Ok(())
     }
@@ -369,21 +371,19 @@ impl PbftNode {
     fn start_view_change_if_enough_messages(
         &mut self,
         vc_message: &PbftViewChange,
+        state: &mut PbftState,
     ) -> Result<bool, PbftError> {
-        if self.state.mode != PbftMode::ViewChanging {
+        if state.mode != PbftMode::ViewChanging {
             // Even if our own timer hasn't expired, still do a ViewChange if we've received
             // f + 1 VC messages to prevent being late to the new view party
             if self
                 .msg_log
-                .check_msg_against_log(&vc_message, true, self.state.f + 1)
+                .check_msg_against_log(&vc_message, true, state.f + 1)
                 .is_ok()
-                && vc_message.get_info().get_view() > self.state.view
+                && vc_message.get_info().get_view() > state.view
             {
-                warn!(
-                    "{}: Starting ViewChange from a ViewChange message",
-                    self.state
-                );
-                self.start_view_change()?;
+                warn!("{}: Starting ViewChange from a ViewChange message", state);
+                self.start_view_change(state)?;
                 Ok(false)
             } else {
                 Ok(true)
@@ -397,26 +397,26 @@ impl PbftNode {
     /// by broadcasting a `PrePrepare` message to peers. Starts a view change timer, just in case
     /// the primary decides not to commit this block. If a `BlockCommit` update doesn't happen in a
     /// timely fashion, then the primary can be considered faulty and a view change should happen.
-    pub fn on_block_new(&mut self, block: Block) -> Result<(), PbftError> {
-        info!("{}: Got BlockNew: {:?}", self.state, block.block_id);
+    pub fn on_block_new(&mut self, block: Block, state: &mut PbftState) -> Result<(), PbftError> {
+        info!("{}: Got BlockNew: {:?}", state, block.block_id);
 
         let pbft_block = pbft_block_from_block(block.clone());
 
         let mut msg = PbftMessage::new();
-        if self.state.is_primary() {
-            self.state.seq_num += 1;
+        if state.is_primary() {
+            state.seq_num += 1;
             msg.set_info(handlers::make_msg_info(
                 &PbftMessageType::BlockNew,
-                self.state.view,
-                self.state.seq_num, // primary knows the proper sequence number
-                self.state.get_own_peer_id(),
+                state.view,
+                state.seq_num, // primary knows the proper sequence number
+                state.get_own_peer_id(),
             ));
         } else {
             msg.set_info(handlers::make_msg_info(
                 &PbftMessageType::BlockNew,
-                self.state.view,
+                state.view,
                 0, // default to unset; change it later when we receive PrePrepare
-                self.state.get_own_peer_id(),
+                state.get_own_peer_id(),
             ));
         }
 
@@ -428,11 +428,11 @@ impl PbftNode {
             .map_err(|e| PbftError::InternalError(e.description().to_string()))?;
 
         if block.block_num > head.block_num + 1
-            || self.state.switch_phase(PbftPhase::PrePreparing).is_none()
+            || state.switch_phase(PbftPhase::PrePreparing).is_none()
         {
             debug!(
                 "{}: Not ready for block {}, pushing to backlog",
-                self.state,
+                state,
                 &hex::encode(block.block_id.clone())[..6]
             );
             self.msg_log.push_block_backlog(block.clone());
@@ -440,12 +440,12 @@ impl PbftNode {
         }
 
         self.msg_log.add_message(msg);
-        self.state.working_block = WorkingBlockOption::TentativeWorkingBlock(block.block_id);
-        self.state.timeout.start();
+        state.working_block = WorkingBlockOption::TentativeWorkingBlock(block.block_id);
+        state.timeout.start();
 
-        if self.state.is_primary() {
-            let s = self.state.seq_num;
-            self._broadcast_pbft_message(s, &PbftMessageType::PrePrepare, pbft_block)?;
+        if state.is_primary() {
+            let s = state.seq_num;
+            self._broadcast_pbft_message(s, &PbftMessageType::PrePrepare, pbft_block, state)?;
         }
         Ok(())
     }
@@ -456,32 +456,36 @@ impl PbftNode {
     /// roles transition back to the `NotStarted` phase. If this node is at a checkpoint after the
     /// previously committed block (`checkpoint_period` blocks have been committed since the last
     /// checkpoint), then start a checkpoint.
-    pub fn on_block_commit(&mut self, block_id: BlockId) -> Result<(), PbftError> {
-        debug!("{}: <<<<<< BlockCommit: {:?}", self.state, block_id);
+    pub fn on_block_commit(
+        &mut self,
+        block_id: BlockId,
+        state: &mut PbftState,
+    ) -> Result<(), PbftError> {
+        debug!("{}: <<<<<< BlockCommit: {:?}", state, block_id);
 
-        if self.state.phase == PbftPhase::Finished {
-            if self.state.is_primary() {
+        if state.phase == PbftPhase::Finished {
+            if state.is_primary() {
                 info!(
                     "{}: Initializing block with previous ID {:?}",
-                    self.state, block_id
+                    state, block_id
                 );
                 self.service
                     .initialize_block(Some(block_id))
                     .unwrap_or_else(|err| error!("Couldn't initialize block: {}", err));
             }
 
-            self.state.switch_phase(PbftPhase::NotStarted);
+            state.switch_phase(PbftPhase::NotStarted);
 
             // Start a checkpoint in NotStarted, if we're at one
             if self.msg_log.at_checkpoint() {
-                self.start_checkpoint()?;
+                self.start_checkpoint(state)?;
             }
         } else {
-            debug!("{}: Not doing anything with BlockCommit", self.state);
+            debug!("{}: Not doing anything with BlockCommit", state);
         }
 
         // The primary processessed this block in a timely manner, so stop the timeout.
-        self.state.timeout.stop();
+        state.timeout.stop();
 
         Ok(())
     }
@@ -490,11 +494,15 @@ impl PbftNode {
     /// This message arrives after `check_blocks` is called, signifying that the validator has
     /// successfully checked a block with this `BlockId`.
     /// Once a `BlockValid` is received, transition to committing blocks.
-    pub fn on_block_valid(&mut self, block_id: BlockId) -> Result<(), PbftError> {
-        debug!("{}: <<<<<< BlockValid: {:?}", self.state, block_id);
-        self.state.switch_phase(PbftPhase::Committing);
+    pub fn on_block_valid(
+        &mut self,
+        block_id: BlockId,
+        state: &mut PbftState,
+    ) -> Result<(), PbftError> {
+        debug!("{}: <<<<<< BlockValid: {:?}", state, block_id);
+        state.switch_phase(PbftPhase::Committing);
 
-        debug!("{}: Getting blocks", self.state);
+        debug!("{}: Getting blocks", state);
         let valid_blocks: Vec<Block> = self
             .service
             .get_blocks(vec![block_id])
@@ -507,11 +515,12 @@ impl PbftNode {
             return Err(PbftError::WrongNumBlocks);
         }
 
-        let s = self.state.seq_num; // By now, secondaries have the proper seq number
+        let s = state.seq_num; // By now, secondaries have the proper seq number
         self._broadcast_pbft_message(
             s,
             &PbftMessageType::Commit,
             handlers::pbft_block_from_block(valid_blocks[0].clone()),
+            state,
         )?;
         Ok(())
     }
@@ -522,24 +531,24 @@ impl PbftNode {
     /// # Panics
     /// Panics if `finalize_block` fails. This is necessary because it means the validator wasn't
     /// able to publish the new block.
-    pub fn try_publish(&mut self) -> Result<(), PbftError> {
+    pub fn try_publish(&mut self, state: &mut PbftState) -> Result<(), PbftError> {
         // Try to finalize a block
-        if self.state.is_primary() && self.state.phase == PbftPhase::NotStarted {
-            debug!("{}: Summarizing block", self.state);
+        if state.is_primary() && state.phase == PbftPhase::NotStarted {
+            debug!("{}: Summarizing block", state);
             if let Err(e) = self.service.summarize_block() {
                 info!(
                     "{}: Couldn't summarize, so not finalizing: {}",
-                    self.state,
+                    state,
                     e.description().to_string()
                 );
             } else {
-                debug!("{}: Trying to finalize block", self.state);
+                debug!("{}: Trying to finalize block", state);
                 match self.service.finalize_block(vec![]) {
                     Ok(block_id) => {
-                        info!("{}: Publishing block {:?}", self.state, block_id);
+                        info!("{}: Publishing block {:?}", state, block_id);
                     }
                     Err(EngineError::BlockNotReady) => {
-                        debug!("{}: Block not ready", self.state);
+                        debug!("{}: Block not ready", state);
                     }
                     Err(err) => panic!("Failed to finalize block: {:?}", err),
                 }
@@ -549,41 +558,41 @@ impl PbftNode {
     }
 
     /// Check to see if the view change timeout has expired
-    pub fn check_timeout_expired(&mut self) -> bool {
-        self.state.timeout.check_expired()
+    pub fn check_timeout_expired(&mut self, state: &mut PbftState) -> bool {
+        state.timeout.check_expired()
     }
 
     /// Start the checkpoint process
     /// Primaries start the checkpoint to ensure sequence number correctness
-    pub fn start_checkpoint(&mut self) -> Result<(), PbftError> {
-        if !self.state.is_primary() {
+    pub fn start_checkpoint(&mut self, state: &mut PbftState) -> Result<(), PbftError> {
+        if !state.is_primary() {
             return Ok(());
         }
-        if self.state.mode == PbftMode::Checkpointing {
+        if state.mode == PbftMode::Checkpointing {
             return Ok(());
         }
 
-        self.state.pre_checkpoint_mode = self.state.mode;
-        self.state.mode = PbftMode::Checkpointing;
-        info!("{}: Starting checkpoint", self.state);
-        let s = self.state.seq_num;
-        self._broadcast_pbft_message(s, &PbftMessageType::Checkpoint, PbftBlock::new())
+        state.pre_checkpoint_mode = state.mode;
+        state.mode = PbftMode::Checkpointing;
+        info!("{}: Starting checkpoint", state);
+        let s = state.seq_num;
+        self._broadcast_pbft_message(s, &PbftMessageType::Checkpoint, PbftBlock::new(), state)
     }
 
     /// Retry messages from the backlog queue
-    pub fn retry_backlog(&mut self) -> Result<(), PbftError> {
+    pub fn retry_backlog(&mut self, state: &mut PbftState) -> Result<(), PbftError> {
         let mut peer_res = Ok(());
         if let Some((msg, sender_id)) = self.msg_log.pop_backlog() {
             debug!(
                 "{}: Popping from backlog {} from {:?}",
-                self.state, msg.message_type, sender_id
+                state, msg.message_type, sender_id
             );
-            peer_res = self.on_peer_message(&msg, &sender_id);
+            peer_res = self.on_peer_message(&msg, &sender_id, state);
         }
-        if self.state.mode == PbftMode::Normal && self.state.phase == PbftPhase::NotStarted {
+        if state.mode == PbftMode::Normal && state.phase == PbftPhase::NotStarted {
             if let Some(msg) = self.msg_log.pop_block_backlog() {
-                debug!("{}: Popping BlockNew from backlog", self.state);
-                self.on_block_new(msg)?;
+                debug!("{}: Popping BlockNew from backlog", state);
+                self.on_block_new(msg, state)?;
             }
         }
         peer_res
@@ -592,18 +601,18 @@ impl PbftNode {
     /// Initiate a view change (this node suspects that the primary is faulty)
     /// Nodes drop everything when they're doing a view change - will not process any peer messages
     /// other than `ViewChanges` until the view change is complete.
-    pub fn start_view_change(&mut self) -> Result<(), PbftError> {
-        if self.state.mode == PbftMode::ViewChanging {
+    pub fn start_view_change(&mut self, state: &mut PbftState) -> Result<(), PbftError> {
+        if state.mode == PbftMode::ViewChanging {
             return Ok(());
         }
-        warn!("{}: Starting view change", self.state);
-        self.state.mode = PbftMode::ViewChanging;
+        warn!("{}: Starting view change", state);
+        state.mode = PbftMode::ViewChanging;
 
         let PbftStableCheckpoint {
             seq_num: stable_seq_num,
             checkpoint_messages,
         } = if let Some(ref cp) = self.msg_log.latest_stable_checkpoint {
-            debug!("{}: No stable checkpoint", self.state);
+            debug!("{}: No stable checkpoint", state);
             cp.clone()
         } else {
             PbftStableCheckpoint {
@@ -614,9 +623,9 @@ impl PbftNode {
 
         let info = handlers::make_msg_info(
             &PbftMessageType::ViewChange,
-            self.state.view + 1,
+            state.view + 1,
             stable_seq_num,
-            self.state.get_own_peer_id(),
+            state.get_own_peer_id(),
         );
 
         let mut vc_msg = PbftViewChange::new();
@@ -627,7 +636,7 @@ impl PbftNode {
             .write_to_bytes()
             .map_err(PbftError::SerializationError)?;
 
-        self._broadcast_message(&PbftMessageType::ViewChange, &msg_bytes)
+        self._broadcast_message(&PbftMessageType::ViewChange, &msg_bytes, state)
     }
 
     // ---------- Methods for communication between nodes ----------
@@ -638,24 +647,20 @@ impl PbftNode {
         seq_num: u64,
         msg_type: &PbftMessageType,
         block: PbftBlock,
+        state: &mut PbftState,
     ) -> Result<(), PbftError> {
-        let expected_type = self.state.check_msg_type();
+        let expected_type = state.check_msg_type();
         // Make sure that we should be sending messages of this type
         if msg_type.is_multicast() && msg_type != &expected_type {
             return Ok(());
         }
 
         let msg_bytes = make_msg_bytes(
-            handlers::make_msg_info(
-                &msg_type,
-                self.state.view,
-                seq_num,
-                self.state.get_own_peer_id(),
-            ),
+            handlers::make_msg_info(&msg_type, state.view, seq_num, state.get_own_peer_id()),
             block,
         ).unwrap_or_default();
 
-        self._broadcast_message(&msg_type, &msg_bytes)
+        self._broadcast_message(&msg_type, &msg_bytes, state)
     }
 
     #[cfg(not(test))]
@@ -663,9 +668,10 @@ impl PbftNode {
         &mut self,
         msg_type: &PbftMessageType,
         msg_bytes: &[u8],
+        state: &mut PbftState,
     ) -> Result<(), PbftError> {
         // Broadcast to peers
-        debug!("{}: Broadcasting {:?}", self.state, msg_type);
+        debug!("{}: Broadcasting {:?}", state, msg_type);
         self.service
             .broadcast(String::from(msg_type).as_str(), msg_bytes.to_vec())
             .unwrap_or_else(|err| error!("Couldn't broadcast: {}", err));
@@ -675,8 +681,8 @@ impl PbftNode {
             message_type: String::from(msg_type),
             content: msg_bytes.to_vec(),
         };
-        let own_peer_id = self.state.get_own_peer_id();
-        self.on_peer_message(&peer_msg, &own_peer_id)
+        let own_peer_id = state.get_own_peer_id();
+        self.on_peer_message(&peer_msg, &own_peer_id, state)
     }
 
     /// NOTE: Disabling self-sending for testing purposes
@@ -685,6 +691,7 @@ impl PbftNode {
         &mut self,
         _msg_type: &PbftMessageType,
         _msg_bytes: &[u8],
+        _state: &mut PbftState,
     ) -> Result<(), PbftError> {
         return Ok(());
     }
@@ -897,7 +904,7 @@ mod tests {
             chain: vec![mock_block_id(0)],
         });
         let cfg = mock_config(4);
-        PbftNode::new(node_id as u64, &cfg, service)
+        PbftNode::new(&cfg, service, node_id == 0)
     }
 
     /// Create a deterministic BlockId hash based on a block number
@@ -963,90 +970,98 @@ mod tests {
     fn block_new() {
         // NOTE: Special case for primary node
         let mut node0 = mock_node(0);
+        let cfg = mock_config(4);
+        let mut state0 = PbftState::new(0, &cfg);
         node0
-            .on_block_new(mock_block(1))
+            .on_block_new(mock_block(1), &mut state0)
             .unwrap_or_else(handle_pbft_err);
-        assert_eq!(node0.state.phase, PbftPhase::PrePreparing);
-        assert_eq!(node0.state.seq_num, 1);
+        assert_eq!(state0.phase, PbftPhase::PrePreparing);
+        assert_eq!(state0.seq_num, 1);
         assert_eq!(
-            node0.state.working_block,
+            state0.working_block,
             WorkingBlockOption::TentativeWorkingBlock(mock_block_id(1))
         );
 
         // Try the next block
         let mut node1 = mock_node(1);
+        let mut state1 = PbftState::new(1, &cfg);
         node1
-            .on_block_new(mock_block(1))
+            .on_block_new(mock_block(1), &mut state1)
             .unwrap_or_else(handle_pbft_err);
-        assert_eq!(node1.state.phase, PbftPhase::PrePreparing);
+        assert_eq!(state1.phase, PbftPhase::PrePreparing);
         assert_eq!(
-            node1.state.working_block,
+            state1.working_block,
             WorkingBlockOption::TentativeWorkingBlock(mock_block_id(1))
         );
-        assert_eq!(node1.state.seq_num, 0);
+        assert_eq!(state1.seq_num, 0);
 
         // Try a block way in the future (push to backlog)
         let mut node1 = mock_node(1);
+        let mut state1 = PbftState::new(1, &cfg);
         node1
-            .on_block_new(mock_block(7))
+            .on_block_new(mock_block(7), &mut state1)
             .unwrap_or_else(handle_pbft_err);
-        assert_eq!(node1.state.phase, PbftPhase::NotStarted);
-        assert_eq!(
-            node1.state.working_block,
-            WorkingBlockOption::NoWorkingBlock
-        );
-        assert_eq!(node1.state.seq_num, 0);
+        assert_eq!(state1.phase, PbftPhase::NotStarted);
+        assert_eq!(state1.working_block, WorkingBlockOption::NoWorkingBlock);
+        assert_eq!(state1.seq_num, 0);
     }
 
     /// Make sure that receiving a `BlockValid` update works as expected
     #[test]
     fn block_valid() {
         let mut node = mock_node(0);
-        node.state.phase = PbftPhase::Checking;
-        node.on_block_valid(mock_block_id(1))
+        let cfg = mock_config(4);
+        let mut state0 = PbftState::new(0, &cfg);
+        state0.phase = PbftPhase::Checking;
+        node.on_block_valid(mock_block_id(1), &mut state0)
             .unwrap_or_else(handle_pbft_err);
-        assert!(node.state.phase == PbftPhase::Committing);
+        assert!(state0.phase == PbftPhase::Committing);
     }
 
     /// Make sure that receiving a `BlockCommit` update works as expected
     #[test]
     fn block_commit() {
         let mut node = mock_node(0);
-        node.state.phase = PbftPhase::Finished;
-        node.on_block_commit(mock_block_id(1))
+        let cfg = mock_config(4);
+        let mut state0 = PbftState::new(0, &cfg);
+        state0.phase = PbftPhase::Finished;
+        node.on_block_commit(mock_block_id(1), &mut state0)
             .unwrap_or_else(handle_pbft_err);
-        assert!(node.state.phase == PbftPhase::NotStarted);
+        assert!(state0.phase == PbftPhase::NotStarted);
     }
 
     /// Test the multicast protocol (`PrePrepare` => `Prepare` => `Commit`)
     #[test]
     fn multicast_protocol() {
         let mut node = mock_node(0);
+        let cfg = mock_config(4);
+        let mut state0 = PbftState::new(0, &cfg);
         let garbage_msg = PeerMessage {
             message_type: String::from(&PbftMessageType::PrePrepare),
             content: b"this message will result in an error".to_vec(),
         };
         assert!(
-            node.on_peer_message(&garbage_msg, &mock_peer_id(0))
+            node.on_peer_message(&garbage_msg, &mock_peer_id(0), &mut state0)
                 .is_err()
         );
 
         // Make sure BlockNew is in the log
         let mut node1 = mock_node(1);
+        let mut state1 = PbftState::new(1, &cfg);
         let block = mock_block(1);
         node1
-            .on_block_new(block.clone())
+            .on_block_new(block.clone(), &mut state1)
             .unwrap_or_else(handle_pbft_err);
 
         // Receive a PrePrepare
         let msg = mock_msg(&PbftMessageType::PrePrepare, 0, 1, block.clone(), 0);
         node1
-            .on_peer_message(&msg, &mock_peer_id(0))
+            .on_peer_message(&msg, &mock_peer_id(0), &mut state1)
             .unwrap_or_else(handle_pbft_err);
 
-        assert_eq!(node1.state.phase, PbftPhase::Preparing);
-        assert_eq!(node1.state.seq_num, 1);
-        if let WorkingBlockOption::WorkingBlock(ref blk) = node1.state.working_block {
+        assert_eq!(state1.phase, PbftPhase::Preparing);
+        assert_eq!(state1.seq_num, 1);
+        if let WorkingBlockOption::WorkingBlock(ref blk) = state1.working_block {
             assert_eq!(BlockId::from(blk.clone().block_id), mock_block_id(1));
         } else {
             panic!("Wrong WorkingBlockOption");
@@ -1054,30 +1069,30 @@ mod tests {
 
         // Receive 3 `Prepare` messages
         for peer in 0..3 {
-            assert_eq!(node1.state.phase, PbftPhase::Preparing);
+            assert_eq!(state1.phase, PbftPhase::Preparing);
             let msg = mock_msg(&PbftMessageType::Prepare, 0, 1, block.clone(), peer);
             node1
-                .on_peer_message(&msg, &mock_peer_id(peer))
+                .on_peer_message(&msg, &mock_peer_id(peer), &mut state1)
                 .unwrap_or_else(handle_pbft_err);
         }
-        assert_eq!(node1.state.phase, PbftPhase::Checking);
+        assert_eq!(state1.phase, PbftPhase::Checking);
 
         // Spoof the `check_blocks()` call
-        assert!(node1.on_block_valid(mock_block_id(1)).is_ok());
+        assert!(node1.on_block_valid(mock_block_id(1), &mut state1).is_ok());
 
         // Receive 3 `Commit` messages
         for peer in 0..3 {
-            assert_eq!(node1.state.phase, PbftPhase::Committing);
+            assert_eq!(state1.phase, PbftPhase::Committing);
             let msg = mock_msg(&PbftMessageType::Commit, 0, 1, block.clone(), peer);
             node1
-                .on_peer_message(&msg, &mock_peer_id(peer))
+                .on_peer_message(&msg, &mock_peer_id(peer), &mut state1)
                 .unwrap_or_else(handle_pbft_err);
         }
-        assert_eq!(node1.state.phase, PbftPhase::Finished);
+        assert_eq!(state1.phase, PbftPhase::Finished);
 
         // Spoof the `commit_blocks()` call
-        assert!(node1.on_block_commit(mock_block_id(1)).is_ok());
-        assert_eq!(node1.state.phase, PbftPhase::NotStarted);
+        assert!(node1.on_block_commit(mock_block_id(1), &mut state1).is_ok());
+        assert_eq!(state1.phase, PbftPhase::NotStarted);
 
         // Make sure the block was actually committed
         let mut f = File::open(BLOCK_FILE).unwrap();
@@ -1101,21 +1116,23 @@ mod tests {
     #[test]
     fn checkpoint() {
         let mut node1 = mock_node(1);
+        let cfg = mock_config(4);
+        let mut state1 = PbftState::new(1, &cfg);
         // Pretend that the node just finished block 10
-        node1.state.seq_num = 10;
+        state1.seq_num = 10;
         let block = mock_block(10);
-        assert_eq!(node1.state.mode, PbftMode::Normal);
+        assert_eq!(state1.mode, PbftMode::Normal);
         assert!(node1.msg_log.latest_stable_checkpoint.is_none());
 
         // Receive 3 `Checkpoint` messages
         for peer in 0..3 {
             let msg = mock_msg(&PbftMessageType::Checkpoint, 0, 10, block.clone(), peer);
             node1
-                .on_peer_message(&msg, &mock_peer_id(peer))
+                .on_peer_message(&msg, &mock_peer_id(peer), &mut state1)
                 .unwrap_or_else(handle_pbft_err);
         }
 
-        assert_eq!(node1.state.mode, PbftMode::Normal);
+        assert_eq!(state1.mode, PbftMode::Normal);
         assert!(node1.msg_log.latest_stable_checkpoint.is_some());
     }
 
@@ -1124,17 +1141,19 @@ mod tests {
     #[test]
     fn view_change() {
         let mut node1 = mock_node(1);
+        let cfg = mock_config(4);
+        let mut state1 = PbftState::new(1, &cfg);
 
-        assert!(!node1.state.is_primary());
+        assert!(!state1.is_primary());
 
         // Receive 3 `ViewChange` messages
         for peer in 0..3 {
             // It takes f + 1 `ViewChange` messages to trigger a view change, if it wasn't started
             // by `start_view_change()`
             if peer < 2 {
-                assert_eq!(node1.state.mode, PbftMode::Normal);
+                assert_eq!(state1.mode, PbftMode::Normal);
             } else {
-                assert_eq!(node1.state.mode, PbftMode::ViewChanging);
+                assert_eq!(state1.mode, PbftMode::ViewChanging);
             }
             let info = make_msg_info(&PbftMessageType::ViewChange, 1, 1, mock_peer_id(peer));
             let mut vc_msg = PbftViewChange::new();
@@ -1147,23 +1166,27 @@ mod tests {
                 content: msg_bytes,
             };
             node1
-                .on_peer_message(&msg, &mock_peer_id(peer))
+                .on_peer_message(&msg, &mock_peer_id(peer), &mut state1)
                 .unwrap_or_else(handle_pbft_err);
         }
 
-        assert!(node1.state.is_primary());
-        assert_eq!(node1.state.view, 1);
+        assert!(state1.is_primary());
+        assert_eq!(state1.view, 1);
     }
 
     /// Make sure that view changes start correctly
     #[test]
     fn start_view_change() {
         let mut node1 = mock_node(1);
-        assert_eq!(node1.state.mode, PbftMode::Normal);
+        let cfg = mock_config(4);
+        let mut state1 = PbftState::new(1, &cfg);
+        assert_eq!(state1.mode, PbftMode::Normal);
 
-        node1.start_view_change().unwrap_or_else(handle_pbft_err);
+        node1
+            .start_view_change(&mut state1)
+            .unwrap_or_else(handle_pbft_err);
 
-        assert_eq!(node1.state.mode, PbftMode::ViewChanging);
+        assert_eq!(state1.mode, PbftMode::ViewChanging);
     }
 
     /// Test that the legitimacy of message senders is verified correctly

--- a/src/state.rs
+++ b/src/state.rs
@@ -32,14 +32,14 @@ use timing::Timeout;
 
 // Possible roles for a node
 // Primary is in charge of making consensus decisions
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 enum PbftNodeRole {
     Primary,
     Secondary,
 }
 
 /// Phases of the PBFT algorithm, in `Normal` mode
-#[derive(Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, PartialOrd, Clone, Serialize, Deserialize)]
 pub enum PbftPhase {
     NotStarted,
     PrePreparing,
@@ -50,7 +50,7 @@ pub enum PbftPhase {
 }
 
 /// Modes that the PBFT algorithm can possibly be in
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
 pub enum PbftMode {
     Normal,
     ViewChanging,
@@ -94,7 +94,7 @@ impl fmt::Display for PbftState {
 }
 
 /// Possible options for the current block
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum WorkingBlockOption {
     /// There is no working block
     NoWorkingBlock,
@@ -114,7 +114,7 @@ impl WorkingBlockOption {
 }
 
 /// Information about the PBFT algorithm's state
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct PbftState {
     /// This node's ID
     pub id: u64,

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018 Bitwise IO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! Disk-backed persistence wrapper
+
+use super::{Storage, StorageReadGuard, StorageWriteGuard};
+use atomicwrites::{AllowOverwrite, AtomicFile};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::{from_str, to_string};
+use std::fmt;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::ops::{Deref, DerefMut};
+
+/// A disk-based read guard
+pub struct DiskStorageReadGuard<'a, T: Serialize + DeserializeOwned + 'a> {
+    storage: &'a DiskStorage<T>,
+}
+
+impl<'a, T: Serialize + DeserializeOwned> DiskStorageReadGuard<'a, T> {
+    fn new(storage: &'a DiskStorage<T>) -> Self {
+        Self { storage }
+    }
+}
+
+impl<'a, T: Serialize + DeserializeOwned + 'a> Deref for DiskStorageReadGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.storage.data
+    }
+}
+
+impl<'a, T: 'a + Serialize + DeserializeOwned + fmt::Display> fmt::Display
+    for DiskStorageReadGuard<'a, T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl<'a, T: 'a + Serialize + DeserializeOwned> StorageReadGuard<'a, T>
+    for DiskStorageReadGuard<'a, T>
+{}
+
+/// A disk-based write guard
+pub struct DiskStorageWriteGuard<'a, T: Serialize + DeserializeOwned + 'a> {
+    storage: &'a mut DiskStorage<T>,
+}
+
+impl<'a, T: Serialize + DeserializeOwned> DiskStorageWriteGuard<'a, T> {
+    fn new(storage: &'a mut DiskStorage<T>) -> Self {
+        Self { storage }
+    }
+}
+
+impl<'a, T: Serialize + DeserializeOwned> Drop for DiskStorageWriteGuard<'a, T> {
+    fn drop(&mut self) {
+        self.storage
+            .file
+            .write(|f| {
+                f.write_all(
+                    to_string(&self.storage.data)
+                        .expect("Couldn't convert value to string!")
+                        .as_bytes(),
+                )
+            }).expect("File write failed while dropping DiskStorageWriteGuard!");
+    }
+}
+
+impl<'a, T: Serialize + DeserializeOwned + 'a> Deref for DiskStorageWriteGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.storage.data
+    }
+}
+
+impl<'a, T: Serialize + DeserializeOwned + 'a> DerefMut for DiskStorageWriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.storage.data
+    }
+}
+
+impl<'a, T: 'a + Serialize + DeserializeOwned + fmt::Display> fmt::Display
+    for DiskStorageWriteGuard<'a, T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl<'a, T: 'a + Serialize + DeserializeOwned> StorageWriteGuard<'a, T>
+    for DiskStorageWriteGuard<'a, T>
+{}
+
+/// A disk-based RAII-guarded Storage implementation
+///
+/// File writes are atomic
+pub struct DiskStorage<T: Serialize + DeserializeOwned> {
+    data: T,
+    file: AtomicFile,
+}
+
+impl<T: Serialize + DeserializeOwned> DiskStorage<T> {
+    pub fn new<P: Into<String>, F: Fn() -> T>(path: P, default: F) -> Result<Self, String> {
+        let path = path.into();
+
+        let file = AtomicFile::new(path, AllowOverwrite);
+
+        // Read the file first, to see if there's any existing data
+        let data = match File::open(file.path()) {
+            Ok(mut f) => {
+                let mut contents = String::new();
+
+                f.read_to_string(&mut contents)
+                    .map_err(|err| format!("Couldn't read file: {}", err))?;
+
+                from_str(&contents).map_err(|err| format!("Couldn't read file: {}", err))?
+            }
+            Err(_) => {
+                let data = default();
+                file.write(|f| f.write_all(to_string(&data)?.as_bytes()))
+                    .map_err(|err| format!("File write failed: {}", err))?;
+
+                data
+            }
+        };
+
+        // Then open the file again and truncate, preparing it to be written to
+        Ok(Self { data, file })
+    }
+}
+
+impl<T: fmt::Display + Serialize + DeserializeOwned> fmt::Display for DiskStorage<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (*self).data.fmt(f)
+    }
+}
+
+impl<T: Serialize + DeserializeOwned> Storage for DiskStorage<T> {
+    type S = T;
+
+    fn read<'a>(&'a self) -> Box<StorageReadGuard<'a, T, Target = T> + 'a> {
+        Box::new(DiskStorageReadGuard::new(self))
+    }
+
+    fn write<'a>(&'a mut self) -> Box<StorageWriteGuard<'a, T, Target = T> + 'a> {
+        Box::new(DiskStorageWriteGuard::new(self))
+    }
+}

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 Bitwise IO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! Memory-backed persistence wrapper
+//!
+//! Useful when a Storage impl is required, but you don't actually need to
+//! persist the wrapped object.
+
+use super::{Storage, StorageReadGuard, StorageWriteGuard};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+
+/// Memory-backed read guard
+#[derive(Debug)]
+pub struct MemStorageReadGuard<'a, T: Serialize + DeserializeOwned + 'a> {
+    storage: &'a MemStorage<T>,
+}
+
+impl<'a, T: Serialize + DeserializeOwned> MemStorageReadGuard<'a, T> {
+    fn new(storage: &'a MemStorage<T>) -> Self {
+        Self { storage }
+    }
+}
+
+impl<'a, T: Serialize + DeserializeOwned + 'a> Deref for MemStorageReadGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.storage.data
+    }
+}
+
+impl<'a, T: 'a + Serialize + DeserializeOwned + fmt::Display> fmt::Display
+    for MemStorageReadGuard<'a, T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl<'a, T: 'a + Serialize + DeserializeOwned> StorageReadGuard<'a, T>
+    for MemStorageReadGuard<'a, T>
+{}
+
+/// Memory-backed write guard
+#[derive(Debug)]
+pub struct MemStorageWriteGuard<'a, T: Serialize + DeserializeOwned + 'a> {
+    storage: &'a mut MemStorage<T>,
+}
+
+impl<'a, T: Serialize + DeserializeOwned> MemStorageWriteGuard<'a, T> {
+    fn new(storage: &'a mut MemStorage<T>) -> Self {
+        Self { storage }
+    }
+}
+
+impl<'a, T: Serialize + DeserializeOwned + 'a> Deref for MemStorageWriteGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.storage.data
+    }
+}
+
+impl<'a, T: Serialize + DeserializeOwned + 'a> DerefMut for MemStorageWriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.storage.data
+    }
+}
+
+impl<'a, T: 'a + Serialize + DeserializeOwned + fmt::Display> fmt::Display
+    for MemStorageWriteGuard<'a, T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl<'a, T: 'a + Serialize + DeserializeOwned> StorageWriteGuard<'a, T>
+    for MemStorageWriteGuard<'a, T>
+{}
+
+/// Memory-backed RAII-guarded Storage implementation
+///
+/// Can be used when actual persistence isn't required
+#[derive(Debug)]
+pub struct MemStorage<T: Serialize + DeserializeOwned> {
+    data: T,
+}
+
+impl<T: Serialize + DeserializeOwned> MemStorage<T> {
+    pub fn new<F: Fn() -> T>(default: F) -> Result<Self, String> {
+        Ok(Self { data: default() })
+    }
+}
+
+impl<T: Serialize + DeserializeOwned + fmt::Display> fmt::Display for MemStorage<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (*self).data.fmt(f)
+    }
+}
+
+impl<T: Serialize + DeserializeOwned> Storage for MemStorage<T> {
+    type S = T;
+
+    fn read<'a>(&'a self) -> Box<StorageReadGuard<'a, T, Target = T> + 'a> {
+        Box::new(MemStorageReadGuard::new(self))
+    }
+
+    fn write<'a>(&'a mut self) -> Box<StorageWriteGuard<'a, T, Target = T> + 'a> {
+        Box::new(MemStorageWriteGuard::new(self))
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2018 Bitwise IO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! Storage trait for syncing writes to an object to a backing store
+//!
+//! Hands out {read, write} RAII-guarded references to an object, and ensures
+//! that when the reference drops, any changes to the object are persisted to
+//! the selected storage.
+
+pub mod disk;
+pub mod memory;
+
+pub use self::disk::DiskStorage;
+pub use self::memory::MemStorage;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::ops::{Deref, DerefMut};
+
+/// RAII structure used to allow read access to state object
+///
+/// This guard allows avoiding unnecessary syncing if you just need read
+/// access to the state object.
+pub trait StorageReadGuard<'a, T: Sized>: Deref<Target = T> {}
+
+/// RAII structure used to allow write access to state object
+///
+/// This guard will ensure that any changes to an object are persisted to
+/// a backing store when this is Dropped.
+pub trait StorageWriteGuard<'a, T: Sized>: DerefMut<Target = T> {}
+
+/// Storage wrapper that ensures that changes to an object are persisted to a backing store
+///
+/// Achieves this by handing out RAII-guarded references to the underlying data, that ensure
+/// persistence when they get Dropped.
+pub trait Storage {
+    type S;
+
+    fn read<'a>(&'a self) -> Box<StorageReadGuard<'a, Self::S, Target = Self::S> + 'a>;
+    fn write<'a>(&'a mut self) -> Box<StorageWriteGuard<'a, Self::S, Target = Self::S> + 'a>;
+}
+
+/// Given a location string, returns the appropriate storage
+///
+/// Accepts `"memory"` or `"disk+/path/to/file"` as location values
+pub fn get_storage<'a, T: Sized + Serialize + DeserializeOwned + 'a, F: Fn() -> T>(
+    location: &str,
+    default: F,
+) -> Result<Box<dyn Storage<S = T> + 'a>, String> {
+    if location == "memory" {
+        Ok(Box::new(MemStorage::new(default).unwrap()) as Box<Storage<S = T>>)
+    } else if location.starts_with("disk") {
+        let split = location.splitn(2, '+').collect::<Vec<_>>();
+
+        if split.len() != 2 {
+            Err(format!("Invalid location: {}", location))?
+        }
+
+        Ok(Box::new(DiskStorage::new(split[1], default).unwrap()))
+    } else {
+        Err(format!("Unknown storage location type: {}", location))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate rand;
+
+    use self::rand::distributions::Alphanumeric;
+    use self::rand::{thread_rng, Rng};
+    use super::*;
+    use super::{DiskStorage, MemStorage};
+    use std::fs::remove_file;
+
+    // The common use case, of passing in a guarded reference
+    fn add_refs(foo: &mut u32, bar: &u32) {
+        *foo += bar;
+    }
+
+    // You can also pass in the storages themselves
+    fn add_storages(foo: &mut (Storage<S = u32>), bar: &mut (Storage<S = u32>)) {
+        **foo.write() += **bar.read();
+    }
+
+    #[test]
+    fn test_read_guard() {
+        let filename = String::from("/tmp/") + &thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(10)
+            .collect::<String>();
+
+        let storage = DiskStorage::new(&filename[..], || 1).unwrap();
+        let val = storage.read();
+        let other = storage.read();
+        assert_eq!(**val, 1);
+        assert_eq!(**other, 1);
+
+        remove_file(filename).unwrap();
+    }
+
+    #[test]
+    // Ensures that data is persisted between object lifetimes
+    fn test_disk_persistence() {
+        let filename = String::from("/tmp/") + &thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(10)
+            .collect::<String>();
+
+        {
+            let mut storage = DiskStorage::new(&filename[..], || 0).unwrap();
+            let mut val = storage.write();
+            **val = 5;
+            assert_eq!(**val, 5);
+        }
+
+        let storage = DiskStorage::new(&filename[..], || 0).unwrap();
+        let val = storage.read();
+        assert_eq!(**val, 5);
+
+        remove_file(filename).unwrap();
+    }
+
+    #[test]
+    // Ensure we don't overwrite longer data with shorter data, and get a mixture of the two
+    fn test_truncation() {
+        let filename = String::from("/tmp/") + &thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(10)
+            .collect::<String>();
+
+        {
+            let storage = DiskStorage::new(&filename[..], || 500).unwrap();
+            let val = storage.read();
+            assert_eq!(**val, 500);
+        }
+
+        {
+            let mut storage = DiskStorage::new(&filename[..], || 0).unwrap();
+            let mut val = storage.write();
+            assert_eq!(**val, 500);
+            **val = 2;
+            assert_eq!(**val, 2);
+        }
+
+        let storage = DiskStorage::new(&filename[..], || 0).unwrap();
+        let val = storage.read();
+        assert_eq!(**val, 2);
+
+        remove_file(filename).unwrap();
+    }
+
+    #[test]
+    fn test_write_guard() {
+        let filename = String::from("/tmp/") + &thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(10)
+            .collect::<String>();
+
+        {
+            let mut storage = DiskStorage::new(&filename[..], || 1).unwrap();
+            let mut val = storage.write();
+            assert_eq!(**val, 1);
+            **val = 5;
+            assert_eq!(**val, 5);
+        }
+
+        {
+            let mut storage = DiskStorage::new(&filename[..], || 1).unwrap();
+            let mut val = storage.write();
+            assert_eq!(**val, 5);
+            **val = 64;
+            assert_eq!(**val, 64);
+        }
+
+        remove_file(filename).unwrap();
+    }
+
+    #[test]
+    fn test_fn_arg() {
+        let filename = String::from("/tmp/") + &thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(10)
+            .collect::<String>();
+
+        let mut diskval = DiskStorage::new(&filename[..], || 1).unwrap();
+        let mut memval = MemStorage::new(|| 5).unwrap();
+
+        assert_eq!(**diskval.read(), 1);
+        add_refs(&mut *diskval.write(), &*memval.read());
+        assert_eq!(**diskval.read(), 6);
+
+        assert_eq!(**memval.read(), 5);
+        add_storages(&mut memval, &mut diskval);
+        assert_eq!(**memval.read(), 11);
+
+        remove_file(filename).unwrap();
+    }
+
+    #[test]
+    fn test_get_storage() {
+        let filename = String::from("/tmp/") + &thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(10)
+            .collect::<String>();
+
+        let memval = get_storage("memory", || 1).unwrap();
+        let mut diskval = get_storage(&format!("disk+{}", filename), || 1).unwrap();
+
+        assert_eq!(**memval.read(), 1);
+
+        {
+            let mut val = diskval.write();
+            **val = 128;
+        }
+
+        assert_eq!(**diskval.read(), 128);
+
+        remove_file(filename).unwrap();
+    }
+}

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -16,7 +16,7 @@
  */
 
 //! Timing-related structures
-
+use serde_millis;
 use std::time::{Duration, Instant};
 
 /// Encapsulates calling a function every so often
@@ -43,7 +43,7 @@ impl Ticker {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 enum TimeoutState {
     Active,
     Inactive,
@@ -52,10 +52,11 @@ enum TimeoutState {
 
 /// A timer that expires after a given duration
 /// Check back on this timer every so often to see if it's expired
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Timeout {
     state: TimeoutState,
     duration: Duration,
+    #[serde(with = "serde_millis")]
     start: Instant,
 }
 


### PR DESCRIPTION
Introduces `Storage` trait that ensures that modifications to an object are synced to a backing store using RAII, and wraps `PbftState` in that. Also moves `PbftState` to be state managed by the engine, for two reasons:

 * `PbftNode` requiring `&mut self` on its methods and also having it hand out references to a contained `PbftState` didn't play nicely with lifetimes
 *  Syncing changes only at the end of each engine loop means we don't have to worry about whether or not any state changes within an engine loop need to be atomic, each loop either gets synced or not