### PR TITLE
Update message signing usage

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -119,7 +119,7 @@ fn handle_update(
             node.start_view_change()?
         }
         Ok(Update::BlockCommit(block_id)) => node.on_block_commit(block_id)?,
-        Ok(Update::PeerMessage(message, _sender_id)) => node.on_peer_message(&message)?,
+        Ok(Update::PeerMessage(message, sender_id)) => node.on_peer_message(&message, &sender_id)?,
         Ok(Update::Shutdown) => return Ok(false),
         Ok(Update::PeerConnected(_)) | Ok(Update::PeerDisconnected(_)) => {
             error!("PBFT currently only supports static networks");

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -26,7 +26,7 @@ use hex;
 
 use protos::pbft_message::{PbftBlock, PbftMessage, PbftMessageInfo, PbftViewChange};
 
-use sawtooth_sdk::consensus::engine::{Block, PeerMessage};
+use sawtooth_sdk::consensus::engine::{Block, PeerId, PeerMessage};
 
 use config::PbftConfig;
 use error::PbftError;
@@ -62,8 +62,8 @@ pub struct PbftLog {
     /// How many cycles in between checkpoints
     checkpoint_period: u64,
 
-    /// Backlog of messages (from peers)
-    backlog: VecDeque<PeerMessage>,
+    /// Backlog of messages (from peers) with sender's ID
+    backlog: VecDeque<(PeerMessage, PeerId)>,
 
     /// Backlog of blocks (from BlockNews messages)
     block_backlog: VecDeque<Block>,
@@ -436,11 +436,11 @@ impl PbftLog {
             .collect();
     }
 
-    pub fn push_backlog(&mut self, msg: PeerMessage) {
-        self.backlog.push_back(msg);
+    pub fn push_backlog(&mut self, msg: PeerMessage, sender_id: PeerId) {
+        self.backlog.push_back((msg, sender_id));
     }
 
-    pub fn pop_backlog(&mut self) -> Option<PeerMessage> {
+    pub fn pop_backlog(&mut self) -> Option<(PeerMessage, PeerId)> {
         self.backlog.pop_front()
     }
 


### PR DESCRIPTION
Adds a verification step for all PBFT messages that compares the
signer_id of the message with the sender_id provided by the validator;
if they do not match, the message is ignored. Since the validator
verifies all peer messages it receives, we can use the sender_id as a
guarantee of who sent the message.