### PR TITLE
Build PBFT on Jenkins nodes matching label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,9 @@
  */
 
 pipeline {
-    agent any
+    agent {
+        label 'master'
+    }
 
     options {
         timestamps()


### PR DESCRIPTION
Jenkins restricts builds to particular labels, and `agent any` doesn't override that. This change makes PBFT build on nodes matching the `master` label.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>