### PR TITLE
Remove duplicates from test peering configuration

### DIFF
--- a/tests/test_liveness.yaml
+++ b/tests/test_liveness.yaml
@@ -88,8 +88,8 @@ services:
             --bind network:tcp://eth0:8800 \
             --bind consensus:tcp://eth0:5050 \
             --peering static \
-            --peers tcp://validator-1:8800,tcp://validator-2:8800,tcp://validator-3:8800
             --scheduler parallel \
+            --maximum-peer-connectivity 3 \
     \""
     stop_signal: SIGKILL
 
@@ -112,8 +112,9 @@ services:
             --bind network:tcp://eth0:8800 \
             --bind consensus:tcp://eth0:5050 \
             --peering static \
-            --peers tcp://validator-0:8800,tcp://validator-2:8800,tcp://validator-3:8800
+            --peers tcp://validator-0:8800
             --scheduler parallel \
+            --maximum-peer-connectivity 3 \
     \""
     stop_signal: SIGKILL
 
@@ -136,8 +137,9 @@ services:
             --bind network:tcp://eth0:8800 \
             --bind consensus:tcp://eth0:5050 \
             --peering static \
-            --peers tcp://validator-0:8800,tcp://validator-1:8800,tcp://validator-3:8800
+            --peers tcp://validator-0:8800,tcp://validator-1:8800
             --scheduler parallel \
+            --maximum-peer-connectivity 3 \
     \""
     stop_signal: SIGKILL
 
@@ -162,6 +164,7 @@ services:
             --peering static \
             --peers tcp://validator-0:8800,tcp://validator-1:8800,tcp://validator-2:8800
             --scheduler parallel \
+            --maximum-peer-connectivity 3 \
     \""
     stop_signal: SIGKILL
 


### PR DESCRIPTION
Update the peering configuration in the liveness test to eliminate the chance
of creating duplicate connections between nodes. Because connections are
bi-directional, only one node per pair of nodes needs to list the other node as
a peer.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>