### PR TITLE
Move PbftGetInfo trait lifetime to method lifetime

### DIFF
--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -26,18 +26,18 @@ use std::hash::{Hash, Hasher};
 use protos::pbft_message::{PbftBlock, PbftMessage, PbftMessageInfo, PbftViewChange};
 
 // All message types that have "info" inside of them
-pub trait PbftGetInfo<'a> {
-    fn get_msg_info(&self) -> &'a PbftMessageInfo;
+pub trait PbftGetInfo {
+    fn get_msg_info(&self) -> &PbftMessageInfo;
 }
 
-impl<'a> PbftGetInfo<'a> for &'a PbftMessage {
-    fn get_msg_info(&self) -> &'a PbftMessageInfo {
+impl<'a> PbftGetInfo for &'a PbftMessage {
+    fn get_msg_info(&self) -> &PbftMessageInfo {
         self.get_info()
     }
 }
 
-impl<'a> PbftGetInfo<'a> for &'a PbftViewChange {
-    fn get_msg_info(&self) -> &'a PbftMessageInfo {
+impl<'a> PbftGetInfo for &'a PbftViewChange {
+    fn get_msg_info(&self) -> &PbftMessageInfo {
         self.get_info()
     }
 }

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -232,9 +232,9 @@ impl PbftLog {
     }
 
     /// Check an incoming message against its counterparts in the message log
-    pub fn check_msg_against_log<'a, T: PbftGetInfo<'a>>(
+    pub fn check_msg_against_log<T: PbftGetInfo>(
         &self,
-        message: &'a T,
+        message: &T,
         check_match: bool,
         num_cutoff: u64,
     ) -> Result<(), PbftError> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -778,7 +778,7 @@ fn extract_multicast_hint(
 }
 
 #[allow(ptr_arg)]
-fn verify_message_sender<'a, T: PbftGetInfo<'a>>(msg: &T, sender_id: &PeerId) -> bool {
+fn verify_message_sender<T: PbftGetInfo>(msg: &T, sender_id: &PeerId) -> bool {
     let signer_id = msg.get_msg_info().get_signer_id().to_vec();
     &signer_id == sender_id
 }


### PR DESCRIPTION
Moves lifetime specification from parameterized for the trait to parameterized by the `get_msg_info` method. We weren't relying on behavior specific to either style, and this lets us elide some lifetimes in code that uses the trait.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>