### PR TITLE
Move action_from_hint logic to PbftLog method

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -32,29 +32,6 @@ use message_log::PbftLog;
 use message_type::{PbftHint, PbftMessageType};
 use state::{PbftPhase, PbftState, WorkingBlockOption};
 
-/// Take action based on a `PbftHint`
-/// Either push to backlog or add message to log, depending on which type of hint
-#[allow(ptr_arg)]
-pub fn action_from_hint(
-    msg_log: &mut PbftLog,
-    hint: &PbftHint,
-    pbft_message: &PbftMessage,
-    msg: Vec<u8>,
-    sender_id: &PeerId,
-) -> Result<(), PbftError> {
-    match hint {
-        PbftHint::FutureMessage => {
-            msg_log.push_backlog(msg, sender_id.clone());
-            Err(PbftError::NotReadyForMessage)
-        }
-        PbftHint::PastMessage => {
-            msg_log.add_message(pbft_message.clone());
-            Err(PbftError::NotReadyForMessage)
-        }
-        PbftHint::PresentMessage => Ok(()),
-    }
-}
-
 /// Handle a `PrePrepare` message
 /// A `PrePrepare` message with this view and sequence number must not already exist in the log. If
 /// this node is a primary, make sure there's a corresponding BlockNew message. If this node is a

--- a/src/node.rs
+++ b/src/node.rs
@@ -109,10 +109,9 @@ impl PbftNode {
                 }
 
                 if !ignore_hint_pre_prepare(state, &pbft_message) {
-                    handlers::action_from_hint(
-                        &mut self.msg_log,
-                        &multicast_hint,
+                    self.msg_log.add_message_with_hint(
                         &pbft_message,
+                        &multicast_hint,
                         msg.to_vec(),
                         sender_id,
                     )?;
@@ -139,10 +138,9 @@ impl PbftNode {
                     return Ok(());
                 }
 
-                handlers::action_from_hint(
-                    &mut self.msg_log,
-                    &multicast_hint,
+                self.msg_log.add_message_with_hint(
                     &pbft_message,
+                    &multicast_hint,
                     msg.to_vec(),
                     sender_id,
                 )?;
@@ -165,10 +163,9 @@ impl PbftNode {
                     return Ok(());
                 }
 
-                handlers::action_from_hint(
-                    &mut self.msg_log,
-                    &multicast_hint,
+                self.msg_log.add_message_with_hint(
                     &pbft_message,
+                    &multicast_hint,
                     msg.to_vec(),
                     sender_id,
                 )?;


### PR DESCRIPTION
Moves logic that handles conditionally adding messages to PbftLog to be inside a method of PbftLog

Signed-off-by: Kenneth Koski <knkski@bitwise.io>