### PR TITLE
Convert bare usize subtraction to checked version

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -900,7 +900,7 @@ mod tests {
             Ok(res)
         }
         fn get_chain_head(&mut self) -> Result<Block, Error> {
-            let prev_num = ::std::panic::catch_unwind(|| self.chain.len() - 2).unwrap_or(0);
+            let prev_num = self.chain.len().checked_sub(2).unwrap_or(0);
             Ok(Block {
                 block_id: self.chain.last().unwrap().clone(),
                 previous_id: self.chain.get(prev_num).unwrap().clone(),


### PR DESCRIPTION
Attempting to subtract a number on a usize that results in a negative number will cause a panic in Rust. That was happening in a test case, and getting caught with `catch_unwind`. We can convert that to `checked_sub` usage, and avoid dealing with panics.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>