### PR TITLE
Update name of clippy rustfmt argument

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
                 sh 'docker-compose run --rm sawtooth-pbft cargo fmt --version'
                 sh 'docker-compose run --rm sawtooth-pbft cargo fmt -- --check'
                 sh 'docker-compose run --rm sawtooth-pbft cargo clippy --version'
-                sh 'docker-compose run --rm sawtooth-pbft cargo clippy -- -D clippy'
+                sh 'docker-compose run --rm sawtooth-pbft cargo clippy -- -D clippy::all'
             }
         }
 


### PR DESCRIPTION
Denying `clippy` warnings is now deprecated in favor of denying `clippy::all` warnings

Signed-off-by: Kenneth Koski <knkski@bitwise.io>