### PR TITLE
Pin Sawtooth SDK revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ log = "0.4"
 log4rs = "0.8"
 log4rs-syslog = "3.0"
 protobuf = { version = "2", features = ["with-serde"] }
-sawtooth_sdk = { git = "https://github.com/hyperledger/sawtooth-core.git", branch = "master" }
+sawtooth_sdk = { git = "https://github.com/hyperledger/sawtooth-core.git", rev = "7ac644d5779a82756ea3d157c02b56ddae2bab17" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
A recent change was merged into the Sawtooth Rust SDK that broke PBFT. Fixing PBFT is non-trivial, so until those changes can be made, pin PBFT to use the revision before those changes were introduced.

The SDK PR can be found here:

https://github.com/hyperledger/sawtooth-core/pull/1923

Signed-off-by: Kenneth Koski <knkski@bitwise.io>