### PR TITLE
Handle Consensus SDK updates

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -135,7 +135,7 @@ fn handle_update(
         }
         Ok(Update::BlockCommit(block_id)) => node.on_block_commit(block_id, state)?,
         Ok(Update::PeerMessage(message, sender_id)) => {
-            node.on_peer_message(&message, &sender_id, state)?
+            node.on_peer_message(&message.content, &sender_id, state)?
         }
         Ok(Update::Shutdown) => return Ok(false),
         Ok(Update::PeerConnected(_)) | Ok(Update::PeerDisconnected(_)) => {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -22,7 +22,7 @@ use hex;
 use std::convert::From;
 use std::error::Error;
 
-use sawtooth_sdk::consensus::engine::{Block, BlockId, PeerId, PeerMessage};
+use sawtooth_sdk::consensus::engine::{Block, BlockId, PeerId};
 use sawtooth_sdk::consensus::service::Service;
 
 use protos::pbft_message::{PbftBlock, PbftMessage, PbftMessageInfo, PbftViewChange};
@@ -39,13 +39,9 @@ pub fn action_from_hint(
     msg_log: &mut PbftLog,
     hint: &PbftHint,
     pbft_message: &PbftMessage,
-    msg_content: Vec<u8>,
+    msg: Vec<u8>,
     sender_id: &PeerId,
 ) -> Result<(), PbftError> {
-    let msg = PeerMessage {
-        message_type: String::from(pbft_message.get_info().get_msg_type()),
-        content: msg_content,
-    };
     match hint {
         PbftHint::FutureMessage => {
             msg_log.push_backlog(msg, sender_id.clone());
@@ -281,11 +277,7 @@ fn check_if_commiting_with_current_chain_head(
             state,
             pbft_message.get_block().block_id.clone()
         );
-        let msg = PeerMessage {
-            message_type: String::from(pbft_message.get_info().get_msg_type()),
-            content: msg_content,
-        };
-        msg_log.push_backlog(msg, sender_id.clone());
+        msg_log.push_backlog(msg_content, sender_id.clone());
         Err(PbftError::BlockMismatch(
             pbft_message.get_block().clone(),
             working_block.clone(),

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -26,7 +26,7 @@ use hex;
 
 use protos::pbft_message::{PbftBlock, PbftMessage, PbftMessageInfo, PbftViewChange};
 
-use sawtooth_sdk::consensus::engine::{Block, PeerId, PeerMessage};
+use sawtooth_sdk::consensus::engine::{Block, PeerId};
 
 use config::PbftConfig;
 use error::PbftError;
@@ -63,7 +63,7 @@ pub struct PbftLog {
     checkpoint_period: u64,
 
     /// Backlog of messages (from peers) with sender's ID
-    backlog: VecDeque<(PeerMessage, PeerId)>,
+    backlog: VecDeque<(Vec<u8>, PeerId)>,
 
     /// Backlog of blocks (from BlockNews messages)
     block_backlog: VecDeque<Block>,
@@ -436,11 +436,11 @@ impl PbftLog {
             .collect();
     }
 
-    pub fn push_backlog(&mut self, msg: PeerMessage, sender_id: PeerId) {
+    pub fn push_backlog(&mut self, msg: Vec<u8>, sender_id: PeerId) {
         self.backlog.push_back((msg, sender_id));
     }
 
-    pub fn pop_backlog(&mut self) -> Option<(PeerMessage, PeerId)> {
+    pub fn pop_backlog(&mut self) -> Option<(Vec<u8>, PeerId)> {
         self.backlog.pop_front()
     }
 

--- a/tests/sawtooth-pbft-test.dockerfile
+++ b/tests/sawtooth-pbft-test.dockerfile
@@ -16,9 +16,9 @@
 
 FROM ubuntu:xenial
 
-RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly xenial universe" >> /etc/apt/sources.list \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/stable xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \
     build-essential \


### PR DESCRIPTION
The Consensus API was recently updated, and most importantly, the PeerMessage type should now be treated as opaque. This commit eliminates construction of PeerMessages in PBFT, and instead passes around the raw bytes from the received PeerMessage.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>