### PR TITLE
Upgrade Docker images to Bionic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN apt-get update \
  && apt-get install -y -q --allow-downgrades \

--- a/Dockerfile-installed
+++ b/Dockerfile-installed
@@ -14,7 +14,7 @@
 # ------------------------------------------------------------------------------
 
 # -------------=== pbft build ===-------------
-FROM ubuntu:xenial as pbft-builder
+FROM ubuntu:bionic as pbft-builder
 
 RUN apt-get update \
  && apt-get install -y -q --allow-downgrades \
@@ -46,7 +46,7 @@ WORKDIR /project/sawtooth-pbft
 RUN /root/.cargo/bin/cargo deb
 
 # -------------=== pbft docker build ===-------------
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 COPY --from=pbft-builder /project/sawtooth-pbft/target/debian/sawtooth*.deb /tmp
 

--- a/adhoc/admin.Dockerfile
+++ b/adhoc/admin.Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
-RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/apt/sources.list \
  && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
  || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
  && apt-get update \

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -13,9 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
-RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \

--- a/tests/sawtooth-pbft-test.dockerfile
+++ b/tests/sawtooth-pbft-test.dockerfile
@@ -14,9 +14,12 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
-RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly xenial universe" >> /etc/apt/sources.list \
+RUN apt update \
+ && apt install gnupg -y
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/apt/sources.list \
  && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
  || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
  && apt-get update \
@@ -35,11 +38,17 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly xenial univers
     python3-requests \
     python3-nose2 \
     sawtooth-smallbank-workload \
-    sawtooth-smallbank-tp-go \
-    sawtooth-xo-tp-go \
+#    sawtooth-smallbank-tp-go \
+#    sawtooth-xo-tp-go \
     unzip \
+    wget \
+    libzmq3-dev \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://build.sawtooth.me/view/all/job/Sawtooth-Hyperledger/job/sawtooth-sdk-go/view/change-requests/job/PR-18/lastSuccessfulBuild/artifact/build/debs/sawtooth-smallbank-tp-go_0.1.2.dev756_amd64.deb
+RUN wget https://build.sawtooth.me/view/all/job/Sawtooth-Hyperledger/job/sawtooth-sdk-go/view/change-requests/job/PR-18/lastSuccessfulBuild/artifact/build/debs/sawtooth-xo-tp-go_0.1.2.dev756_amd64.deb
+RUN apt install ./*.deb
 
 RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
  && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \


### PR DESCRIPTION
Bleeding edge packages are no longer getting published for xenial, and PBFT needs those packages due to https://github.com/hyperledger/sawtooth-core/pull/1933. Includes some temporary Dockerfile changes to pull in Go SDK PR code that will go away once that code is merged/published.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>