### PR TITLE
Add retry clause to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,6 +83,10 @@ pipeline {
         }
 
         stage('Run integration tests') {
+            // Until the non-deterministic failures get figured out, just jiggle it a couple of times
+            options {
+                retry(3)
+            }
             steps {
                 sh 'docker-compose -f tests/test_liveness.yaml run pbft-0 cargo build'
                 sh 'docker-compose -f tests/test_liveness.yaml up --abort-on-container-exit --exit-code-from test-pbft-engine'


### PR DESCRIPTION
The liveness tests have a non-deterministic failure that occasionally breaks builds. Try the failing step a few times, in case that's why it broke.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>