### PR TITLE
Chown artifacts to jenkins uid

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
         stage("Archive Build artifacts") {
             steps {
                 sh 'docker-compose -f docker-compose-installed.yaml build'
-                sh 'docker run --rm -v $(pwd)/build/debs:/build sawtooth-pbft-engine:${ISOLATION_ID} bash -c "cp /tmp/sawtooth-pbft-engine*.deb /build"'
+                sh 'docker run --rm -v $(pwd)/build/debs:/build sawtooth-pbft-engine:${ISOLATION_ID} bash -c "cp /tmp/sawtooth-pbft-engine*.deb /build && chown ${JENKINS_UID} /build/*.deb"'
             }
         }
     }


### PR DESCRIPTION
Jenkins is unable to properly cleanup if this isn't done.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>