### PR TITLE
Implement node catchup RFC

### DIFF
--- a/tests/test_crash_fault_tolerance.sh
+++ b/tests/test_crash_fault_tolerance.sh
@@ -74,7 +74,7 @@ docker exec $ADMIN bash -c '\
 echo "All nodes have reached block 10!"
 
 echo "Shutting down alpha node"
-docker-compose -p ${ISOLATION_ID}-alpha -f adhoc/node.yaml stop pbft
+docker-compose -p ${ISOLATION_ID}-alpha -f adhoc/node.yaml stop
 
 echo "Waiting for remaining nodes to reach block 20"
 docker exec $ADMIN bash -c '\
@@ -97,7 +97,7 @@ docker exec $ADMIN bash -c '\
 echo "All nodes have reached block 20!"
 
 echo "Restarting alpha node"
-docker-compose -p ${ISOLATION_ID}-alpha -f adhoc/node.yaml start pbft
+docker-compose -p ${ISOLATION_ID}-alpha -f adhoc/node.yaml start
 
 echo "Waiting for all nodes to reach block 30"
 docker exec $ADMIN bash -c '\


### PR DESCRIPTION
Adds a try_catchup method to PbftNode that is called on BlockNew that will attempt to catch the node up if it has fallen behind.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>