### PR TITLE
Move CFT services to separate compose file

### DIFF
--- a/tests/sawtooth-services.yaml
+++ b/tests/sawtooth-services.yaml
@@ -1,0 +1,53 @@
+# Copyright 2018 Bitwise IO, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Defines the normal Sawtooth services that PBFT Docker tests rely on,
+# so that a test can run `docker-compose -f $THIS_FILE build` to ensure
+# that those images exist if they don't already. These services run from
+# a shared PBFT test dockerfile that installs the Sawtooth services from
+# apt.
+
+version: "3.6"
+
+services:
+  validator:
+    image: sawtooth-validator:${ISOLATION_ID}
+    build:
+      context: .
+      dockerfile: sawtooth-pbft-test.dockerfile
+
+  rest-api:
+    image: sawtooth-rest-api:${ISOLATION_ID}
+    build:
+      context: .
+      dockerfile: sawtooth-pbft-test.dockerfile
+
+  intkey-tp-python:
+    image: sawtooth-intkey-tp-python:${ISOLATION_ID}
+    build:
+      context: .
+      dockerfile: sawtooth-pbft-test.dockerfile
+
+  settings-tp:
+    image: sawtooth-settings-tp:${ISOLATION_ID}
+    build:
+      context: .
+      dockerfile: sawtooth-pbft-test.dockerfile
+
+  workload:
+    image: sawtooth-intkey-workload:${ISOLATION_ID}
+    build:
+      context: .
+      dockerfile: sawtooth-pbft-test.dockerfile

--- a/tests/test_crash_fault_tolerance.sh
+++ b/tests/test_crash_fault_tolerance.sh
@@ -22,6 +22,9 @@
 
 if [ -z "$ISOLATION_ID " ]; then export ISOLATION_ID=latest; fi
 
+echo "Ensuring sawtooth services are built"
+docker-compose -p ${ISOLATION_ID} -f /project/sawtooth-pbft/tests/sawtooth-services.yaml build
+
 echo "Starting initial network"
 docker-compose -p ${ISOLATION_ID} -f /project/sawtooth-pbft/adhoc/admin.yaml up -d
 docker-compose -p ${ISOLATION_ID}-alpha -f /project/sawtooth-pbft/adhoc/node.yaml up -d

--- a/tests/test_crash_fault_tolerance.yaml
+++ b/tests/test_crash_fault_tolerance.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-version: "2.1"
+version: "3.6"
 
 services:
 

--- a/tests/test_crash_fault_tolerance.yaml
+++ b/tests/test_crash_fault_tolerance.yaml
@@ -30,33 +30,3 @@ services:
     environment:
       SAWTOOTH_PBFT: $SAWTOOTH_PBFT
       ISOLATION_ID: $ISOLATION_ID
-
-  validator:
-    image: sawtooth-validator:${ISOLATION_ID}
-    build:
-      context: .
-      dockerfile: sawtooth-pbft-test.dockerfile
-
-  rest-api:
-    image: sawtooth-rest-api:${ISOLATION_ID}
-    build:
-      context: .
-      dockerfile: sawtooth-pbft-test.dockerfile
-
-  intkey-tp-python:
-    image: sawtooth-intkey-tp-python:${ISOLATION_ID}
-    build:
-      context: .
-      dockerfile: sawtooth-pbft-test.dockerfile
-
-  settings-tp:
-    image: sawtooth-settings-tp:${ISOLATION_ID}
-    build:
-      context: .
-      dockerfile: sawtooth-pbft-test.dockerfile
-
-  workload:
-    image: sawtooth-intkey-workload:${ISOLATION_ID}
-    build:
-      context: .
-      dockerfile: sawtooth-pbft-test.dockerfile


### PR DESCRIPTION
Moves sawtooth services defined in CFT compose file to separate compose file. This will let us reuse the compose file in any new tests, as well as avoid having to specify `--no-abort` when running the CFT compose file.