### PR TITLE
Implement dynamic membership

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -225,13 +225,7 @@ pub fn get_peers_from_settings<S: std::hash::BuildHasher>(
 /// hash.
 #[cfg(test)]
 pub fn mock_config(num_nodes: usize) -> PbftConfig {
-    use hash::hash_sha256;
-
-    let ids = (0..num_nodes)
-        .map(|i| PeerId::from(hash_sha256(format!("I'm a node with ID {}", i).as_bytes())))
-        .collect::<Vec<_>>();
-
     let mut config = PbftConfig::default();
-    config.peers = ids;
+    config.peers = (0..num_nodes).map(|id| vec![id as u8]).collect();
     config
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -141,7 +141,7 @@ fn handle_update(
         }
         Ok(Update::Shutdown) => return Ok(false),
         Ok(Update::PeerConnected(_)) | Ok(Update::PeerDisconnected(_)) => {
-            error!("PBFT currently only supports static networks");
+            debug!("Received PeerConnected/PeerDisconnected message");
         }
         Err(RecvTimeoutError::Timeout) => return Err(PbftError::Timeout),
         Err(RecvTimeoutError::Disconnected) => {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -54,16 +54,9 @@ impl Engine for PbftEngine {
         // Load on-chain settings
         let config = config::load_pbft_config(chain_head.block_id, &mut *service);
 
-        let node_id = config
-            .peers
-            .iter()
-            .position(|ref id| id == &&local_peer_info.peer_id)
-            .ok_or_else(|| {
-                Error::UnknownPeer("This node is not in the peers list, which is necessary".into())
-            })? as u64;
-
-        let mut pbft_state = get_storage(&config.storage, || PbftState::new(node_id, &config))
-            .expect("Couldn't load state!");
+        let mut pbft_state = get_storage(&config.storage, || {
+            PbftState::new(local_peer_info.peer_id.clone(), &config)
+        }).expect("Couldn't load state!");
 
         let mut working_ticker = timing::Ticker::new(config.block_duration);
         let mut backlog_ticker = timing::Ticker::new(config.message_timeout);

--- a/src/node.rs
+++ b/src/node.rs
@@ -538,6 +538,11 @@ impl PbftNode {
     /// the primary decides not to commit this block. If a `BlockCommit` update doesn't happen in a
     /// timely fashion, then the primary can be considered faulty and a view change should happen.
     pub fn on_block_new(&mut self, block: Block, state: &mut PbftState) -> Result<(), PbftError> {
+        if block.block_num == 0 {
+            info!("Got genesis block as BlockNew; skipping");
+            return Ok(());
+        }
+
         info!("{}: Got BlockNew: {:?}", state, block.block_id);
 
         let pbft_block = pbft_block_from_block(block.clone());

--- a/src/state.rs
+++ b/src/state.rs
@@ -23,7 +23,6 @@ use hex;
 use sawtooth_sdk::consensus::engine::{BlockId, PeerId};
 
 use config::PbftConfig;
-use error::PbftError;
 use message_type::PbftMessageType;
 use protos::pbft_message::PbftBlock;
 use timing::Timeout;
@@ -85,7 +84,7 @@ impl fmt::Display for PbftState {
 
         write!(
             f,
-            "({} {} {}, seq {}, wb {}), Node {}{:02}",
+            "({} {} {}, seq {}, wb {}), Node {}{:?}",
             phase, mode, self.view, self.seq_num, wb, ast, self.id,
         )
     }
@@ -115,7 +114,7 @@ impl WorkingBlockOption {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PbftState {
     /// This node's ID
-    pub id: u64,
+    pub id: PeerId,
 
     /// The node's current sequence number
     /// Always starts at 0; representative of an unknown sequence number.
@@ -159,7 +158,8 @@ impl PbftState {
     /// # Panics
     /// Panics if the network this node is on does not have enough nodes to be Byzantine fault
     /// tolernant.
-    pub fn new(id: u64, config: &PbftConfig) -> Self {
+    #[allow(needless_pass_by_value)]
+    pub fn new(id: PeerId, config: &PbftConfig) -> Self {
         // Maximum number of faulty nodes in this network. Panic if there are not enough nodes.
         let f = ((config.peers.len() - 1) / 3) as u64;
         if f == 0 {
@@ -167,11 +167,11 @@ impl PbftState {
         }
 
         PbftState {
-            id,
+            id: id.clone(),
             seq_num: 0, // Default to unknown
             view: 0,    // Node ID 0 is default primary
             phase: PbftPhase::NotStarted,
-            role: if id == 0 {
+            role: if config.peers[0] == id {
                 PbftNodeRole::Primary
             } else {
                 PbftNodeRole::Secondary
@@ -203,26 +203,10 @@ impl PbftState {
         }
     }
 
-    /// Obtain the node ID (u64) from a serialized PeerId
-    pub fn get_node_id_from_bytes(&self, peer_id: &[u8]) -> Result<u64, PbftError> {
-        let deser_id = peer_id.to_vec();
-
-        if let Some(node_id) = self.peer_ids.iter().position(|ref info| info == &&deser_id) {
-            Ok(node_id as u64)
-        } else {
-            Err(PbftError::NodeNotFound)
-        }
-    }
-
-    /// Obtain the Peer ID for this node
-    pub fn get_own_peer_id(&self) -> PeerId {
-        self.peer_ids[self.id as usize].clone()
-    }
-
-    /// Obtain the Peer ID for the primary node in the network
-    pub fn get_primary_peer_id(&self) -> PeerId {
-        let primary_node_id = (self.view % (self.peer_ids.len() as u64)) as usize;
-        self.peer_ids[primary_node_id].clone()
+    /// Obtain the ID for the primary node in the network
+    pub fn get_primary_id(&self) -> PeerId {
+        let primary_index = (self.view % (self.peer_ids.len() as u64)) as usize;
+        self.peer_ids[primary_index].clone()
     }
 
     /// Tell if this node is currently the primary
@@ -289,7 +273,7 @@ mod tests {
     fn no_fault_tolerance() {
         let config = mock_config(1);
         let caught = ::std::panic::catch_unwind(|| {
-            PbftState::new(0, &config);
+            PbftState::new(vec![0], &config);
         }).is_err();
         assert!(caught);
     }
@@ -303,8 +287,8 @@ mod tests {
     #[test]
     fn initial_config() {
         let config = mock_config(4);
-        let state0 = PbftState::new(0, &config);
-        let state1 = PbftState::new(1, &config);
+        let state0 = PbftState::new(vec![0], &config);
+        let state1 = PbftState::new(vec![], &config);
 
         assert!(state0.is_primary());
         assert!(!state1.is_primary());
@@ -315,31 +299,15 @@ mod tests {
         assert_eq!(state0.check_msg_type(), PbftMessageType::Unset);
         assert_eq!(state1.check_msg_type(), PbftMessageType::Unset);
 
-        assert_eq!(
-            state0
-                .get_node_id_from_bytes(&Vec::<u8>::from(state0.peer_ids[0].clone()))
-                .unwrap(),
-            0
-        );
-        assert_eq!(
-            state1
-                .get_node_id_from_bytes(&Vec::<u8>::from(state1.peer_ids[1].clone()))
-                .unwrap(),
-            1
-        );
-
-        assert_eq!(state0.get_own_peer_id(), state0.peer_ids[0]);
-        assert_eq!(state1.get_own_peer_id(), state1.peer_ids[1]);
-
-        assert_eq!(state0.get_primary_peer_id(), state0.peer_ids[0]);
-        assert_eq!(state1.get_primary_peer_id(), state1.peer_ids[0]);
+        assert_eq!(state0.get_primary_id(), state0.peer_ids[0]);
+        assert_eq!(state1.get_primary_id(), state1.peer_ids[0]);
     }
 
     /// Make sure that nodes transition from primary to secondary and back smoothly
     #[test]
     fn role_changes() {
         let config = mock_config(4);
-        let mut state = PbftState::new(0, &config);
+        let mut state = PbftState::new(vec![0], &config);
 
         state.downgrade_role();
         assert!(!state.is_primary());
@@ -355,7 +323,7 @@ mod tests {
     #[test]
     fn phase_changes() {
         let config = mock_config(4);
-        let mut state = PbftState::new(0, &config);
+        let mut state = PbftState::new(vec![0], &config);
 
         assert!(state.switch_phase(PbftPhase::PrePreparing).is_some());
         assert!(state.switch_phase(PbftPhase::Preparing).is_some());

--- a/src/state.rs
+++ b/src/state.rs
@@ -135,7 +135,7 @@ pub struct PbftState {
     pub pre_checkpoint_mode: PbftMode,
 
     /// Map of peers in the network, including ourselves
-    peer_ids: Vec<PeerId>,
+    pub peer_ids: Vec<PeerId>,
 
     /// The maximum number of faulty nodes in the network
     pub f: u64,

--- a/tests/test_dynamic_membership.sh
+++ b/tests/test_dynamic_membership.sh
@@ -190,7 +190,7 @@ docker exec -e API=${INIT_APIS[0]} $ADMIN bash -c '\
   SETTING_PEERS=($(sawtooth settings list --url "http://$API:8008" \
     --filter "sawtooth.consensus.pbft.peers" --format csv | sed -n 2p | \
     sed "s/\"\",\"\"/\ /g")); \
-  until [[ "${#SETTING_PEERS[@]}" -eq 5 ]]; do \
+  until [[ "${#SETTING_PEERS[@]}" -eq 6 ]]; do \
     echo "Attempting to set sawtooth.consensus.pbft.peers..."; \
     # Try to update setting \
     sawset proposal create -k /shared_data/keys/settings.priv \


### PR DESCRIPTION
Implements membership changes for PBFT according to the following
procedure:

1. When a block is committed, check the list of peers in the
`sawtooth.consensus.pbft.peers` setting to see if it matches the current
list of peers stored in PBFT state.
2. If the 2 lists of peers differ, update the PBFT state's list of
peers, recalculate the value of f (max number of faulty nodes), and
force a view change.

Signed-off-by: Logan Seeley <seeley@bitwise.io>