### PR TITLE
Move PbftLog to PbftState

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -68,7 +68,7 @@ impl Engine for PbftEngine {
         let mut working_ticker = timing::Ticker::new(config.block_duration);
         let mut backlog_ticker = timing::Ticker::new(config.message_timeout);
 
-        let mut node = PbftNode::new(&config, service, pbft_state.read().is_primary());
+        let mut node = PbftNode::new(service, pbft_state.read().is_primary());
 
         debug!("Starting state: {:#?}", **pbft_state.read());
 

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -31,13 +31,14 @@ use message_type::{ParsedMessage, PbftHint, PbftMessageType, PbftMessageWrapper}
 use protos::pbft_message::{PbftBlock, PbftMessage, PbftMessageInfo, PbftViewChange};
 
 /// The log keeps track of the last stable checkpoint
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PbftStableCheckpoint {
     pub seq_num: u64,
     pub checkpoint_messages: Vec<PbftMessage>,
 }
 
 /// Struct for storing messages that a PbftNode receives
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PbftLog {
     /// Generic messages (BlockNew, PrePrepare, Prepare, Commit, Checkpoint)
     messages: HashSet<ParsedMessage>,

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -30,7 +30,7 @@ use error::PbftError;
 use protos::pbft_message::{PbftBlock, PbftMessage, PbftMessageInfo, PbftViewChange};
 
 /// Wrapper enum for all of the possible PBFT-related messages
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PbftMessageWrapper {
     Message(PbftMessage),
     ViewChange(PbftViewChange),
@@ -40,7 +40,7 @@ pub enum PbftMessageWrapper {
 ///
 /// The bits of the `PeerMessage` struct that this carries around are used in
 /// constructing the consensus seal.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct ParsedMessage {
     /// Serialized ConsensusPeerMessageHeader. Inserted into the consensus seal.
     pub header_bytes: Vec<u8>,

--- a/src/node.rs
+++ b/src/node.rs
@@ -28,11 +28,10 @@ use sawtooth_sdk::consensus::service::Service;
 use sawtooth_sdk::messages::consensus::ConsensusPeerMessageHeader;
 use sawtooth_sdk::signing::{create_context, secp256k1::Secp256k1PublicKey};
 
-use config::PbftConfig;
 use error::PbftError;
 use handlers;
 use hash::verify_sha512;
-use message_log::{PbftLog, PbftStableCheckpoint};
+use message_log::PbftStableCheckpoint;
 use message_type::{ParsedMessage, PbftHint, PbftMessageType};
 use protos::pbft_message::{
     PbftBlock, PbftMessage, PbftMessageInfo, PbftSeal, PbftSignedCommitVote, PbftViewChange,
@@ -48,7 +47,7 @@ pub struct PbftNode {
 impl PbftNode {
     /// Construct a new PBFT node.
     /// After the node is created, if the node is primary, it initializes a new block on the chain.
-    pub fn new(config: &PbftConfig, service: Box<Service>, is_primary: bool) -> Self {
+    pub fn new(service: Box<Service>, is_primary: bool) -> Self {
         let mut n = PbftNode { service };
 
         // Primary initializes a block
@@ -1033,8 +1032,7 @@ mod tests {
             // Create genesis block (but with actual ID)
             chain: vec![mock_block_id(0)],
         });
-        let cfg = mock_config(4);
-        PbftNode::new(&cfg, service, node_id == 0)
+        PbftNode::new(service, node_id == 0)
     }
 
     /// Create a deterministic BlockId hash based on a block number

--- a/src/state.rs
+++ b/src/state.rs
@@ -24,6 +24,7 @@ use sawtooth_sdk::consensus::engine::{BlockId, PeerId};
 
 use config::PbftConfig;
 use error::PbftError;
+use message_log::PbftLog;
 use message_type::PbftMessageType;
 use protos::pbft_message::PbftBlock;
 use timing::Timeout;
@@ -152,6 +153,9 @@ pub struct PbftState {
 
     /// The current block this node is working on
     pub working_block: WorkingBlockOption,
+
+    /// Messages this node has received
+    pub msg_log: PbftLog,
 }
 
 impl PbftState {
@@ -184,6 +188,7 @@ impl PbftState {
             idle_timeout: Timeout::new(config.idle_timeout),
             forced_view_change_period: config.forced_view_change_period,
             working_block: WorkingBlockOption::NoWorkingBlock,
+            msg_log: PbftLog::new(config),
         }
     }
 


### PR DESCRIPTION
Lets PbftLog be revived after a crash. Currently requires `Block` from the Rust SDK to have `Serialize`/`Deserialize` derived.