### PR TITLE
Fix view number lookup issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ with-serde = []
 atomicwrites = "0.2"
 clap = "2.31"
 hex = "0.3"
+itertools = "0.7"
 log = "0.4"
 log4rs = "0.8"
 log4rs-syslog = "3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ extern crate clap;
 #[macro_use]
 extern crate log;
 extern crate hex;
+extern crate itertools;
 extern crate log4rs;
 extern crate log4rs_syslog;
 extern crate openssl;


### PR DESCRIPTION
Forced view changes were causing issues with looking up votes for publishing by view number. The previous fix looked back a single view number, this provides a more general solution.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>