### PR TITLE
Updating code formatting with cargo fmt

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -40,7 +40,8 @@ fn main() {
             serde_derive: Some(true),
             ..Default::default()
         },
-    }).expect("Protoc Error");
+    })
+    .expect("Protoc Error");
 
     // Create mod.rs accordingly
     let mut mod_file = File::create(dest_path.join("mod.rs")).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,7 +110,8 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
                 String::from("sawtooth.consensus.pbft.message_timeout"),
                 String::from("sawtooth.consensus.pbft.max_log_size"),
             ],
-        ).expect("Failed to get on-chain settings");
+        )
+        .expect("Failed to get on-chain settings");
 
     // Get the peers associated with this node (including ourselves). Panic if it is not provided;
     // the network cannot function without this setting.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -56,7 +56,8 @@ impl Engine for PbftEngine {
 
         let mut pbft_state = get_storage(&config.storage, || {
             PbftState::new(local_peer_info.peer_id.clone(), &config)
-        }).expect("Couldn't load state!");
+        })
+        .expect("Couldn't load state!");
 
         let mut working_ticker = timing::Ticker::new(config.block_duration);
         let mut backlog_ticker = timing::Ticker::new(config.message_timeout);
@@ -73,9 +74,11 @@ impl Engine for PbftEngine {
             let state = &mut **pbft_state.write();
 
             match handle_update(&mut node, incoming_message, state) {
-                Ok(again) => if !again {
-                    break;
-                },
+                Ok(again) => {
+                    if !again {
+                        break;
+                    }
+                }
                 Err(err) => handle_pbft_result(Err(err)),
             }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -161,7 +161,7 @@ fn set_current_working_block(state: &mut PbftState, pbft_message: &PbftMessage) 
 /// Once a `2f + 1` `Commit` messages are received, the primary node can commit the block to the
 /// chain. If the block in the message isn't the one that belongs on top of the current chain head,
 /// then the message gets pushed to the backlog.
-#[allow(ptr_arg)]
+#[allow(clippy::ptr_arg)]
 pub fn commit(
     state: &mut PbftState,
     msg_log: &mut PbftLog,
@@ -219,7 +219,7 @@ fn check_if_block_already_seen(
     }
 }
 
-#[allow(ptr_arg)]
+#[allow(clippy::ptr_arg)]
 fn check_if_commiting_with_current_chain_head(
     state: &mut PbftState,
     msg_log: &mut PbftLog,
@@ -421,7 +421,7 @@ fn become_secondary(state: &mut PbftState) {
     state.downgrade_role();
 }
 
-#[allow(ptr_arg)]
+#[allow(clippy::ptr_arg)]
 // There should only be one block with a matching ID
 fn get_block_by_id(service: &mut Service, block_id: &BlockId) -> Option<Block> {
     let blocks: Vec<Block> = service

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,8 @@ fn get_console_config(log_level: log::LevelFilter) -> Config {
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(
             "{h({l:5.5})} | {({M}:{L}):20.20} | {m}{n}",
-        ))).build();
+        )))
+        .build();
 
     Config::builder()
         .appender(Appender::builder().build("stdout", Box::new(stdout)))
@@ -132,7 +133,8 @@ fn parse_args() -> PbftCliArgs {
         (@arg verbose: -v --verbose +multiple
          "increase output verbosity")
         (@arg logconfig: -L --log_config +takes_value
-         "path to logging config file")).get_matches();
+         "path to logging config file"))
+    .get_matches();
 
     let log_config = matches.value_of("logconfig").map(|s| s.into());
 

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -19,7 +19,7 @@
 
 // We know that the property `k1 == k2 ==>  hash(k1) == hash(k2)` holds, since protobuf just compares
 // every field in the struct and that's exactly what the implementation of Hash is doing below
-#![allow(unknown_lints, derive_hash_xor_eq)]
+#![allow(unknown_lints, clippy::derive_hash_xor_eq)]
 
 use std::fmt;
 use std::hash::{Hash, Hasher};

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -362,7 +362,6 @@ impl PbftLog {
         view: u64,
         block: &PbftBlock,
     ) -> usize {
-        #[allow(map_clone)]
         let zero_seq_msgs: Vec<ParsedMessage> = self
             .get_messages_of_type(msg_type, 0, view)
             .iter()
@@ -420,7 +419,6 @@ impl PbftLog {
         self.cycles = 0;
 
         // Update the stable checkpoint
-        #[allow(map_clone)]
         let cp_msgs: Vec<PbftMessage> = self
             .get_messages_of_type(&PbftMessageType::Checkpoint, stable_checkpoint, view)
             .iter()

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -79,7 +79,8 @@ impl fmt::Display for PbftLog {
                 self.view_changes
                     .iter()
                     .map(|ref msg| msg.get_info().clone()),
-            ).collect();
+            )
+            .collect();
         let string_infos: Vec<String> = msg_infos
             .iter()
             .map(|info: &PbftMessageInfo| -> String {
@@ -90,7 +91,8 @@ impl fmt::Display for PbftLog {
                     info.get_seq_num(),
                     hex::encode(info.get_signer_id()),
                 )
-            }).collect();
+            })
+            .collect();
 
         write!(
             f,
@@ -316,7 +318,8 @@ impl PbftLog {
                 info.get_msg_type() == String::from(msg_type)
                     && info.get_seq_num() == sequence_number
                     && info.get_view() == view
-            }).collect()
+            })
+            .collect()
     }
 
     /// Obtain message information objects from the log that match a given type, sequence number,
@@ -437,7 +440,8 @@ impl PbftLog {
             .filter(|ref msg| {
                 let seq_num = msg.info().get_seq_num();
                 seq_num >= self.get_latest_checkpoint() && seq_num > 0
-            }).cloned()
+            })
+            .cloned()
             .collect();
         self.view_changes = self
             .view_changes
@@ -445,7 +449,8 @@ impl PbftLog {
             .filter(|ref msg| {
                 let seq_num = msg.get_info().get_seq_num();
                 seq_num >= self.get_latest_checkpoint() && seq_num > 0
-            }).cloned()
+            })
+            .cloned()
             .collect();
     }
 

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -285,7 +285,7 @@ impl PbftLog {
     /// Future messages are added to the backlog of messages to handle at a later time
     /// Present messages are ignored, as they're generally added immediately after
     /// this method is called by the calling code, except for `PrePrepare` messages
-    #[allow(ptr_arg)]
+    #[allow(clippy::ptr_arg)]
     pub fn add_message_with_hint(
         &mut self,
         msg: ParsedMessage,

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -17,7 +17,7 @@
 
 //! Message types for PeerMessages
 
-#![allow(unknown_lints, derive_hash_xor_eq)]
+#![allow(unknown_lints, clippy::derive_hash_xor_eq)]
 
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -197,7 +197,7 @@ impl ParsedMessage {
     }
 
     /// Constructs a copy of this message with the given message type
-    #[allow(needless_pass_by_value)]
+    #[allow(clippy::needless_pass_by_value)]
     pub fn as_msg_type(&self, msg_type: PbftMessageType) -> ParsedMessage {
         let mut new_msg = self.get_pbft_message().clone();
         let mut info = new_msg.take_info();

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -169,11 +169,13 @@ impl ParsedMessage {
                 } else {
                     Some(PbftMessageWrapper::Message(m))
                 }
-            }).or_else(|| {
+            })
+            .or_else(|| {
                 protobuf::parse_from_bytes::<PbftViewChange>(&message.content)
                     .ok()
                     .and_then(|m| Some(PbftMessageWrapper::ViewChange(m)))
-            }).ok_or_else(|| PbftError::InternalError("Couldn't parse message!".into()))?;
+            })
+            .ok_or_else(|| PbftError::InternalError("Couldn't parse message!".into()))?;
 
         Ok(Self {
             header_bytes: message.header_bytes,

--- a/src/node.rs
+++ b/src/node.rs
@@ -72,7 +72,7 @@ impl PbftNode {
     /// This method handles all messages from other nodes. Such messages may include `PrePrepare`,
     /// `Prepare`, `Commit`, `Checkpoint`, or `ViewChange`. If a node receives a type of message
     /// before it is ready to do so, the message is pushed into a backlog queue.
-    #[allow(needless_pass_by_value)]
+    #[allow(clippy::needless_pass_by_value)]
     pub fn on_peer_message(
         &mut self,
         msg: ParsedMessage,
@@ -206,7 +206,7 @@ impl PbftNode {
         Ok(())
     }
 
-    #[allow(ptr_arg)]
+    #[allow(clippy::ptr_arg)]
     fn commit_block_if_committing(
         &mut self,
         msg: &ParsedMessage,
@@ -246,7 +246,7 @@ impl PbftNode {
         }
     }
 
-    #[allow(ptr_arg)]
+    #[allow(clippy::ptr_arg)]
     fn check_if_checkpoint_started(&mut self, msg: &ParsedMessage, state: &mut PbftState) -> bool {
         // Not ready to receive checkpoint yet; only acceptable in NotStarted
         if state.phase != PbftPhase::NotStarted {

--- a/src/node.rs
+++ b/src/node.rs
@@ -433,13 +433,7 @@ impl PbftNode {
         let peer_ids: HashSet<_> = peers
             .iter()
             .cloned()
-            .filter_map(|pid| {
-                if pid == block.signer_id {
-                    None
-                } else {
-                    Some(pid)
-                }
-            })
+            .filter(|pid| pid != &block.signer_id)
             .collect();
 
         if !voter_ids.is_subset(&peer_ids) {

--- a/src/node.rs
+++ b/src/node.rs
@@ -426,7 +426,8 @@ impl PbftNode {
             .get_settings(
                 block.previous_id.clone(),
                 vec![String::from("sawtooth.consensus.pbft.peers")],
-            ).expect("Failed to get settings");
+            )
+            .expect("Failed to get settings");
         let peers = get_peers_from_settings(&settings);
 
         let peer_ids: HashSet<_> = peers
@@ -438,7 +439,8 @@ impl PbftNode {
                 } else {
                     Some(pid)
                 }
-            }).collect();
+            })
+            .collect();
 
         if !voter_ids.is_subset(&peer_ids) {
             return Err(PbftError::InternalError(format!(
@@ -827,7 +829,8 @@ impl PbftNode {
                     vote.set_message_bytes(m.message_bytes.clone());
 
                     vote
-                }).collect::<Vec<_>>(),
+                })
+                .collect::<Vec<_>>(),
         ));
 
         seal.write_to_bytes().map_err(PbftError::SerializationError)
@@ -988,7 +991,8 @@ impl PbftNode {
             .get_settings(
                 block_id,
                 vec![String::from("sawtooth.consensus.pbft.peers")],
-            ).expect("Failed to get settings");
+            )
+            .expect("Failed to get settings");
         let peers = get_peers_from_settings(&settings);
         let new_peers_set: HashSet<PeerId> = peers.iter().cloned().collect();
 
@@ -1027,7 +1031,8 @@ impl PbftNode {
         let msg_bytes = make_msg_bytes(
             handlers::make_msg_info(&msg_type, state.view, seq_num, state.id.clone()),
             block,
-        ).unwrap_or_default();
+        )
+        .unwrap_or_default();
 
         self._broadcast_message(&msg_type, msg_bytes, state)
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -164,7 +164,7 @@ impl PbftState {
     /// # Panics
     /// Panics if the network this node is on does not have enough nodes to be Byzantine fault
     /// tolernant.
-    #[allow(needless_pass_by_value)]
+    #[allow(clippy::needless_pass_by_value)]
     pub fn new(id: PeerId, config: &PbftConfig) -> Self {
         // Maximum number of faulty nodes in this network. Panic if there are not enough nodes.
         let f = ((config.peers.len() - 1) / 3) as u64;

--- a/src/state.rs
+++ b/src/state.rs
@@ -280,7 +280,8 @@ mod tests {
         let config = mock_config(1);
         let caught = ::std::panic::catch_unwind(|| {
             PbftState::new(vec![0], &config);
-        }).is_err();
+        })
+        .is_err();
         assert!(caught);
     }
 

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -58,7 +58,8 @@ impl<'a, T: 'a + Serialize + DeserializeOwned + fmt::Display> fmt::Display
 
 impl<'a, T: 'a + Serialize + DeserializeOwned> StorageReadGuard<'a, T>
     for DiskStorageReadGuard<'a, T>
-{}
+{
+}
 
 /// A disk-based write guard
 pub struct DiskStorageWriteGuard<'a, T: Serialize + DeserializeOwned + 'a> {
@@ -81,7 +82,8 @@ impl<'a, T: Serialize + DeserializeOwned> Drop for DiskStorageWriteGuard<'a, T> 
                         .expect("Couldn't convert value to string!")
                         .as_bytes(),
                 )
-            }).expect("File write failed while dropping DiskStorageWriteGuard!");
+            })
+            .expect("File write failed while dropping DiskStorageWriteGuard!");
     }
 }
 
@@ -109,7 +111,8 @@ impl<'a, T: 'a + Serialize + DeserializeOwned + fmt::Display> fmt::Display
 
 impl<'a, T: 'a + Serialize + DeserializeOwned> StorageWriteGuard<'a, T>
     for DiskStorageWriteGuard<'a, T>
-{}
+{
+}
 
 /// A disk-based RAII-guarded Storage implementation
 ///

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -123,7 +123,7 @@ pub struct DiskStorage<T: Serialize + DeserializeOwned> {
 }
 
 impl<T: Serialize + DeserializeOwned> DiskStorage<T> {
-    pub fn new<P: Into<String>, F: Fn() -> T>(path: P, default: F) -> Result<Self, String> {
+    pub fn from_path<P: Into<String>, F: Fn() -> T>(path: P, default: F) -> Result<Self, String> {
         let path = path.into();
 
         let file = AtomicFile::new(path, AllowOverwrite);

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -58,7 +58,8 @@ impl<'a, T: 'a + Serialize + DeserializeOwned + fmt::Display> fmt::Display
 
 impl<'a, T: 'a + Serialize + DeserializeOwned> StorageReadGuard<'a, T>
     for MemStorageReadGuard<'a, T>
-{}
+{
+}
 
 /// Memory-backed write guard
 #[derive(Debug)]
@@ -96,7 +97,8 @@ impl<'a, T: 'a + Serialize + DeserializeOwned + fmt::Display> fmt::Display
 
 impl<'a, T: 'a + Serialize + DeserializeOwned> StorageWriteGuard<'a, T>
     for MemStorageWriteGuard<'a, T>
-{}
+{
+}
 
 /// Memory-backed RAII-guarded Storage implementation
 ///

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -109,8 +109,8 @@ pub struct MemStorage<T: Serialize + DeserializeOwned> {
 }
 
 impl<T: Serialize + DeserializeOwned> MemStorage<T> {
-    pub fn new<F: Fn() -> T>(default: F) -> Result<Self, String> {
-        Ok(Self { data: default() })
+    pub fn new<F: Fn() -> T>(default: F) -> Self {
+        Self { data: default() }
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -99,10 +99,11 @@ mod tests {
 
     #[test]
     fn test_read_guard() {
-        let filename = String::from("/tmp/") + &thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(10)
-            .collect::<String>();
+        let filename = String::from("/tmp/")
+            + &thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .collect::<String>();
 
         let storage = DiskStorage::new(&filename[..], || 1).unwrap();
         let val = storage.read();
@@ -116,10 +117,11 @@ mod tests {
     #[test]
     // Ensures that data is persisted between object lifetimes
     fn test_disk_persistence() {
-        let filename = String::from("/tmp/") + &thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(10)
-            .collect::<String>();
+        let filename = String::from("/tmp/")
+            + &thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .collect::<String>();
 
         {
             let mut storage = DiskStorage::new(&filename[..], || 0).unwrap();
@@ -138,10 +140,11 @@ mod tests {
     #[test]
     // Ensure we don't overwrite longer data with shorter data, and get a mixture of the two
     fn test_truncation() {
-        let filename = String::from("/tmp/") + &thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(10)
-            .collect::<String>();
+        let filename = String::from("/tmp/")
+            + &thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .collect::<String>();
 
         {
             let storage = DiskStorage::new(&filename[..], || 500).unwrap();
@@ -166,10 +169,11 @@ mod tests {
 
     #[test]
     fn test_write_guard() {
-        let filename = String::from("/tmp/") + &thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(10)
-            .collect::<String>();
+        let filename = String::from("/tmp/")
+            + &thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .collect::<String>();
 
         {
             let mut storage = DiskStorage::new(&filename[..], || 1).unwrap();
@@ -192,10 +196,11 @@ mod tests {
 
     #[test]
     fn test_fn_arg() {
-        let filename = String::from("/tmp/") + &thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(10)
-            .collect::<String>();
+        let filename = String::from("/tmp/")
+            + &thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .collect::<String>();
 
         let mut diskval = DiskStorage::new(&filename[..], || 1).unwrap();
         let mut memval = MemStorage::new(|| 5).unwrap();
@@ -213,10 +218,11 @@ mod tests {
 
     #[test]
     fn test_get_storage() {
-        let filename = String::from("/tmp/") + &thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(10)
-            .collect::<String>();
+        let filename = String::from("/tmp/")
+            + &thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .collect::<String>();
 
         let memval = get_storage("memory", || 1).unwrap();
         let mut diskval = get_storage(&format!("disk+{}", filename), || 1).unwrap();


### PR DESCRIPTION
`cargo fmt` updated recently and introduced new formatting. This updates PBFT to match the new formatting. Also fixes clippy lints.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>