### PR TITLE
 Check view number matches when adding msg to log

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -74,7 +74,7 @@ fn check_pre_prepare_does_not_exist(
     info: &PbftMessageInfo,
 ) -> Result<(), PbftError> {
     // Check that this PrePrepare doesn't already exist
-    let existing_pre_prep_msgs = msg_log.get_messages_of_type(
+    let existing_pre_prep_msgs = msg_log.get_messages_of_type_seq_view(
         &PbftMessageType::PrePrepare,
         info.get_seq_num(),
         info.get_view(),
@@ -92,7 +92,7 @@ fn check_pre_prepare_matches_original_block_new(
     pbft_message: &PbftMessage,
     info: &PbftMessageInfo,
 ) -> Result<(), PbftError> {
-    let block_new_msgs = msg_log.get_messages_of_type(
+    let block_new_msgs = msg_log.get_messages_of_type_seq_view(
         &PbftMessageType::BlockNew,
         info.get_seq_num(),
         info.get_view(),

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -442,7 +442,7 @@ mod tests {
         Block {
             block_id: mock_block_id(num),
             previous_id: mock_block_id(num - 1),
-            signer_id: PeerId::from(vec![]),
+            signer_id: PeerId::from(vec![0]),
             block_num: num,
             payload: vec![],
             summary: vec![],
@@ -481,7 +481,7 @@ mod tests {
         log0.add_message(block_new0, &state0);
         state0.seq_num = 1;
 
-        let block_new1 = mock_msg(&PbftMessageType::BlockNew, 0, 0, mock_block(1), vec![0]);
+        let block_new1 = mock_msg(&PbftMessageType::BlockNew, 0, 1, mock_block(1), vec![0]);
         log1.add_message(block_new1, &state1);
 
         assert!(pre_prepare(&mut state0, &mut log0, &pre_prep_msg).is_ok());

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -522,11 +522,11 @@ mod tests {
 
         // Put the block new in the log
         let block_new0 = mock_msg(&PbftMessageType::BlockNew, 0, 1, mock_block(1), vec![0]);
-        log0.add_message(block_new0);
+        log0.add_message(block_new0, &state0);
         state0.seq_num = 1;
 
         let block_new1 = mock_msg(&PbftMessageType::BlockNew, 0, 0, mock_block(1), vec![0]);
-        log1.add_message(block_new1);
+        log1.add_message(block_new1, &state1);
 
         assert!(pre_prepare(&mut state0, &mut log0, &pre_prep_msg).is_ok());
         assert!(pre_prepare(&mut state1, &mut log1, &pre_prep_msg).is_ok());

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -172,7 +172,8 @@ impl PbftLog {
         info: &PbftMessageInfo,
         msg_type: &PbftMessageType,
     ) -> Option<&ParsedMessage> {
-        let msgs = self.get_messages_of_type(msg_type, info.get_seq_num(), info.get_view());
+        let msgs =
+            self.get_messages_of_type_seq_view(msg_type, info.get_seq_num(), info.get_view());
         msgs.first().cloned()
     }
 
@@ -185,7 +186,7 @@ impl PbftLog {
         check_block: bool,
         required: u64,
     ) -> bool {
-        let msgs = self.get_messages_of_type(
+        let msgs = self.get_messages_of_type_seq_view(
             msg_type,
             ref_msg.info().get_seq_num(),
             ref_msg.info().get_view(),
@@ -268,7 +269,7 @@ impl PbftLog {
     }
 
     /// Obtain messages from the log that match a given type, sequence number, and view
-    pub fn get_messages_of_type(
+    pub fn get_messages_of_type_seq_view(
         &self,
         msg_type: &PbftMessageType,
         sequence_number: u64,
@@ -391,7 +392,7 @@ impl PbftLog {
 
         // Update the stable checkpoint
         let cp_msgs: Vec<PbftMessage> = self
-            .get_messages_of_type(&PbftMessageType::Checkpoint, stable_checkpoint, view)
+            .get_messages_of_type_seq_view(&PbftMessageType::Checkpoint, stable_checkpoint, view)
             .iter()
             .map(|&cp| cp.get_pbft_message().clone())
             .collect();
@@ -488,7 +489,7 @@ mod tests {
 
         log.add_message(msg.clone(), &state);
 
-        let gotten_msgs = log.get_messages_of_type(&PbftMessageType::PrePrepare, 1, 0);
+        let gotten_msgs = log.get_messages_of_type_seq_view(&PbftMessageType::PrePrepare, 1, 0);
 
         assert_eq!(gotten_msgs.len(), 1);
         assert_eq!(&msg, gotten_msgs[0]);
@@ -677,16 +678,19 @@ mod tests {
                 PbftMessageType::Prepare,
                 PbftMessageType::Commit,
             ] {
-                assert_eq!(log.get_messages_of_type(&msg_type, old, 0).len(), 0);
+                assert_eq!(
+                    log.get_messages_of_type_seq_view(&msg_type, old, 0).len(),
+                    0
+                );
             }
         }
 
         for msg_type in &[PbftMessageType::BlockNew, PbftMessageType::PrePrepare] {
-            assert_eq!(log.get_messages_of_type(&msg_type, 4, 0).len(), 1);
+            assert_eq!(log.get_messages_of_type_seq_view(&msg_type, 4, 0).len(), 1);
         }
 
         for msg_type in &[PbftMessageType::Prepare, PbftMessageType::Commit] {
-            assert_eq!(log.get_messages_of_type(&msg_type, 4, 0).len(), 4);
+            assert_eq!(log.get_messages_of_type_seq_view(&msg_type, 4, 0).len(), 4);
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -638,30 +638,24 @@ impl PbftNode {
             return Ok(());
         }
 
-        let pbft_block = pbft_block_from_block(block.clone());
-
-        let mut msg = PbftMessage::new();
         if state.is_primary() {
             // Ensure that our local state doesn't get out of sync with actual state
             state.seq_num = head.block_num + 1;
-
-            msg.set_info(handlers::make_msg_info(
-                &PbftMessageType::BlockNew,
-                state.view,
-                state.seq_num, // primary knows the proper sequence number
-                state.id.clone(),
-            ));
         } else {
             // Ensure that our local state doesn't get out of sync with actual state
             state.seq_num = head.block_num;
-
-            msg.set_info(handlers::make_msg_info(
-                &PbftMessageType::BlockNew,
-                state.view,
-                0, // default to unset; change it later when we receive PrePrepare
-                state.id.clone(),
-            ));
         }
+
+        let mut msg = PbftMessage::new();
+
+        msg.set_info(handlers::make_msg_info(
+            &PbftMessageType::BlockNew,
+            state.view,
+            block.block_num,
+            state.id.clone(),
+        ));
+
+        let pbft_block = pbft_block_from_block(block.clone());
 
         msg.set_block(pbft_block.clone());
 


### PR DESCRIPTION
Updates `add_message` to check all messages that aren't Checkpoints or
ViewChanges to see if the view number matches the node's current view;
if it does not, do not add the message to the log. This is guarantee of
the PBFT algorithm that was not previously implemented. Also requires
passing state to `add_message`.

Signed-off-by: Logan Seeley <seeley@bitwise.io>