### PR TITLE
Add build discarding to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
 
     options {
         timestamps()
+        buildDiscarder(logRotator(daysToKeepStr: '31'))
     }
 
     environment {


### PR DESCRIPTION
Mirrors the BuildDiscarderProperty bit from the other, older-syntax Jenkinsfiles that we have.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>