### PR TITLE
Message log improvements

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -123,7 +123,7 @@ fn handle_update(
 ) -> Result<bool, PbftError> {
     match incoming_message {
         Ok(Update::BlockNew(block)) => node.on_block_new(block, state)?,
-        Ok(Update::BlockValid(block_id)) => node.on_block_valid(block_id, state)?,
+        Ok(Update::BlockValid(block_id)) => node.on_block_valid(&block_id, state)?,
         Ok(Update::BlockInvalid(_)) => {
             warn!("{}: BlockInvalid received, starting view change", state);
             node.propose_view_change(state)?

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ pub enum PbftError {
     /// The message already exists in the log
     MessageExists(PbftMessageType),
 
-    /// Insufficient number of messages recieved so far (expected, got)
+    /// Too many or too few messages recieved so far (expected, got)
     WrongNumMessages(PbftMessageType, usize, usize),
 
     /// The block in the message doesn't match the one this node was expecting

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -373,7 +373,7 @@ fn check_received_enough_view_changes(
     msg_log: &PbftLog,
     vc_message: &ParsedMessage,
 ) -> Result<(), PbftError> {
-    msg_log.check_msg_against_log(vc_message, true, 2 * state.f + 1)
+    msg_log.check_msg_against_log(vc_message.info(), true, 2 * state.f + 1)
 }
 
 fn set_current_view_from_msg(state: &mut PbftState, vc_message: &ParsedMessage) {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -338,7 +338,9 @@ pub fn view_change(
     service: &mut Service,
     vc_message: &ParsedMessage,
 ) -> Result<(), PbftError> {
-    check_received_enough_view_changes(state, msg_log, vc_message)?;
+    if !check_received_enough_view_changes(state, msg_log, vc_message) {
+        return Ok(());
+    }
 
     set_current_view_from_msg(state, vc_message);
 
@@ -372,8 +374,13 @@ fn check_received_enough_view_changes(
     state: &PbftState,
     msg_log: &PbftLog,
     vc_message: &ParsedMessage,
-) -> Result<(), PbftError> {
-    msg_log.check_msg_against_log(vc_message.info(), true, 2 * state.f + 1)
+) -> bool {
+    msg_log.log_has_required_msgs(
+        &PbftMessageType::ViewChange,
+        vc_message,
+        false,
+        2 * state.f + 1,
+    )
 }
 
 fn set_current_view_from_msg(state: &mut PbftState, vc_message: &ParsedMessage) {

--- a/src/node.rs
+++ b/src/node.rs
@@ -112,7 +112,7 @@ impl PbftNode {
 
                 self.msg_log.add_message(msg.clone());
 
-                self.msg_log.check_prepared(&msg, state.f)?;
+                self.msg_log.check_prepared(&msg.info(), state.f)?;
 
                 self.check_blocks_if_not_checking(&msg, state)?;
             }
@@ -123,7 +123,7 @@ impl PbftNode {
 
                 self.msg_log.add_message(msg.clone());
 
-                self.msg_log.check_committable(&msg, state.f)?;
+                self.msg_log.check_committable(&msg.info(), state.f)?;
 
                 self.commit_block_if_committing(&msg, state)?;
             }
@@ -280,7 +280,7 @@ impl PbftNode {
     ) -> Result<(), PbftError> {
         if state.mode == PbftMode::Checkpointing {
             self.msg_log
-                .check_msg_against_log(pbft_message, true, 2 * state.f + 1)?;
+                .check_msg_against_log(pbft_message.info(), true, 2 * state.f + 1)?;
             warn!(
                 "{}: Reached stable checkpoint (seq num {}); garbage collecting logs",
                 state,
@@ -306,7 +306,7 @@ impl PbftNode {
             // f + 1 VC messages to prevent being late to the new view party
             if self
                 .msg_log
-                .check_msg_against_log(message, true, state.f + 1)
+                .check_msg_against_log(message.info(), true, state.f + 1)
                 .is_ok()
                 && message.info().get_view() > state.view
             {

--- a/src/node.rs
+++ b/src/node.rs
@@ -148,7 +148,6 @@ impl PbftNode {
             }
 
             PbftMessageType::ViewChange => {
-                let vc_message = msg.get_view_change_message();
                 let info = msg.info();
                 debug!(
                     "{}: Received ViewChange message from Node {:?} (v {}, seq {})",
@@ -158,7 +157,7 @@ impl PbftNode {
                     info.get_seq_num(),
                 );
 
-                self.msg_log.add_view_change(vc_message.clone());
+                self.msg_log.add_message(msg.clone());
 
                 if self.propose_view_change_if_enough_messages(&msg, state)? {
                     return Ok(());

--- a/src/node.rs
+++ b/src/node.rs
@@ -1652,7 +1652,7 @@ mod tests {
             } else {
                 assert_eq!(state1.mode, PbftMode::ViewChanging);
             }
-            let info = make_msg_info(&PbftMessageType::ViewChange, 1, 1, vec![peer]);
+            let info = make_msg_info(&PbftMessageType::ViewChange, 1, 0, vec![peer]);
             let mut vc_msg = PbftViewChange::new();
             vc_msg.set_info(info);
             vc_msg.set_checkpoint_messages(RepeatedField::default());

--- a/src/node.rs
+++ b/src/node.rs
@@ -760,15 +760,16 @@ impl PbftNode {
     /// This message arrives after `check_blocks` is called, signifying that the validator has
     /// successfully checked a block with this `BlockId`.
     /// Once a `BlockValid` is received, transition to committing blocks.
+    #[allow(clippy::ptr_arg)]
     pub fn on_block_valid(
         &mut self,
-        block_id: BlockId,
+        block_id: &BlockId,
         state: &mut PbftState,
     ) -> Result<(), PbftError> {
         debug!("{}: <<<<<< BlockValid: {:?}", state, block_id);
         let block = match state.working_block {
             WorkingBlockOption::WorkingBlock(ref block) => {
-                if BlockId::from(block.get_block_id()) == block_id {
+                if &BlockId::from(block.get_block_id()) == block_id {
                     Ok(block.clone())
                 } else {
                     warn!("Got BlockValid that doesn't match the working block");
@@ -1521,7 +1522,7 @@ mod tests {
         state0.phase = PbftPhase::Checking;
         state0.working_block =
             WorkingBlockOption::WorkingBlock(pbft_block_from_block(mock_block(1)));
-        node.on_block_valid(mock_block_id(1), &mut state0)
+        node.on_block_valid(&mock_block_id(1), &mut state0)
             .unwrap_or_else(handle_pbft_err);
         assert_eq!(state0.phase, PbftPhase::Committing);
     }
@@ -1576,7 +1577,7 @@ mod tests {
         assert_eq!(state1.phase, PbftPhase::Checking);
 
         // Spoof the `check_blocks()` call
-        assert!(node1.on_block_valid(mock_block_id(1), &mut state1).is_ok());
+        assert!(node1.on_block_valid(&mock_block_id(1), &mut state1).is_ok());
 
         // Receive 3 `Commit` messages
         for peer in 0..3 {


### PR DESCRIPTION
Various improvements to the message log and related code. Most notably:
- Updates the check_prepared and check_committable methods to:
  * Be easier to read and understand
  * Return a bool in their returned Results instead of a () to
    distinguish between actual errors and the predicate simply being false
  * Perform all necessary checks and verifications (i.e. did not check
    if blocks matched between messages before)
- Replaces the check_msg_against_log method with a more understandable
  and flexible method log_has_required_msgs