### PR TITLE
Updates to PrePrepare + Commit processes, sequence number ordering

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -52,10 +52,14 @@ impl Engine for PbftEngine {
         } = startup_state;
 
         // Load on-chain settings
-        let config = config::load_pbft_config(chain_head.block_id, &mut *service);
+        let config = config::load_pbft_config(chain_head.block_id.clone(), &mut *service);
 
         let mut pbft_state = get_storage(&config.storage, || {
-            PbftState::new(local_peer_info.peer_id.clone(), &config)
+            PbftState::new(
+                local_peer_info.peer_id.clone(),
+                chain_head.block_num,
+                &config,
+            )
         })
         .expect("Couldn't load state!");
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,10 @@ pub enum PbftError {
     /// The message is in a different view than this node is
     ViewMismatch(usize, usize),
 
+    /// The message has a sequence number that is not between watermarks
+    /// (message's sequence number, low watermark, high watermark)
+    InvalidSequenceNumber(usize, usize, usize),
+
     /// Internal PBFT error (description)
     InternalError(String),
 
@@ -76,6 +80,7 @@ impl Error for PbftError {
             BlockMismatch(_, _) => "BlockMismatch",
             MessageMismatch(_) => "MessageMismatch",
             ViewMismatch(_, _) => "ViewMismatch",
+            InvalidSequenceNumber(_, _, _) => "InvalidSequenceNumber",
             InternalError(_) => "InternalError",
             NodeNotFound => "NodeNotFound",
             WrongNumBlocks => "WrongNumBlocks",
@@ -103,6 +108,11 @@ impl fmt::Display for PbftError {
             ),
             PbftError::MessageMismatch(t) => write!(f, "{:?} message mismatch", t),
             PbftError::ViewMismatch(exp, got) => write!(f, "View mismatch: {} != {}", exp, got),
+            PbftError::InvalidSequenceNumber(got, low, high) => write!(
+                f,
+                "Invalid sequence number: {} is not in range [{},{})",
+                got, low, high
+            ),
             PbftError::BlockMismatch(exp, got) => write!(
                 f,
                 "{:?} != {:?}",

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -478,11 +478,11 @@ mod tests {
 
         // Put the block new in the log
         let block_new0 = mock_msg(&PbftMessageType::BlockNew, 0, 1, mock_block(1), vec![0]);
-        log0.add_message(block_new0, &state0);
+        log0.add_message(block_new0, &state0).unwrap();
         state0.seq_num = 1;
 
         let block_new1 = mock_msg(&PbftMessageType::BlockNew, 0, 1, mock_block(1), vec![0]);
-        log1.add_message(block_new1, &state1);
+        log1.add_message(block_new1, &state1).unwrap();
 
         assert!(pre_prepare(&mut state0, &mut log0, &pre_prep_msg).is_ok());
         assert!(pre_prepare(&mut state1, &mut log1, &pre_prep_msg).is_ok());

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -41,7 +41,7 @@ use state::{PbftPhase, PbftState, WorkingBlockOption};
 /// - The message's view matches the node's current view (handled by message log)
 /// - The sequence number is between the low and high watermarks (handled by message log)
 ///
-/// If a `PrePrepare` message is accepted, we update the phase, working block, and sequence number
+/// If a `PrePrepare` message is accepted, we update the phase and working block
 pub fn pre_prepare(
     state: &mut PbftState,
     msg_log: &mut PbftLog,
@@ -343,8 +343,8 @@ mod tests {
     #[test]
     fn test_pre_prepare() {
         let cfg = config::mock_config(4);
-        let mut state0 = PbftState::new(vec![0], &cfg);
-        let mut state1 = PbftState::new(vec![1], &cfg);
+        let mut state0 = PbftState::new(vec![0], 0, &cfg);
+        let mut state1 = PbftState::new(vec![1], 0, &cfg);
         let mut log0 = PbftLog::new(&cfg);
         let mut log1 = PbftLog::new(&cfg);
 
@@ -371,7 +371,7 @@ mod tests {
     #[test]
     fn test_multicast_hint() {
         let cfg = config::mock_config(4);
-        let mut state = PbftState::new(vec![0], &cfg);
+        let mut state = PbftState::new(vec![0], 0, &cfg);
         state.seq_num = 5;
 
         // Past (past sequence number)

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -205,17 +205,22 @@ impl PbftLog {
     }
 
     /// Add a generic PBFT message to the log
-    pub fn add_message(&mut self, msg: ParsedMessage, state: &PbftState) {
+    pub fn add_message(&mut self, msg: ParsedMessage, state: &PbftState) -> Result<(), PbftError> {
+        // The sequence number must be between the watermarks
         if msg.info().get_seq_num() >= self.high_water_mark
             || msg.info().get_seq_num() < self.low_water_mark
         {
-            warn!(
-                "Not adding message with sequence number {}; outside of log bounds ({}, {})",
+            error!(
+                "Got message with invalid sequence number: {} is not in range [{},{})",
                 msg.info().get_seq_num(),
                 self.low_water_mark,
                 self.high_water_mark,
             );
-            return;
+            return Err(PbftError::InvalidSequenceNumber(
+                msg.info().get_seq_num() as usize,
+                self.low_water_mark as usize,
+                self.high_water_mark as usize,
+            ));
         }
 
         // Except for Checkpoints and ViewChanges, the message must be for the current view to be
@@ -225,12 +230,15 @@ impl PbftLog {
             && msg_type != PbftMessageType::ViewChange
             && msg.info().get_view() != state.view
         {
-            warn!(
-                "Not adding message with view number {}; does not match node's view: {}",
+            error!(
+                "Got message with mismatched view number; {} != {}",
                 msg.info().get_view(),
                 state.view,
             );
-            return;
+            return Err(PbftError::ViewMismatch(
+                msg.info().get_view() as usize,
+                state.view as usize,
+            ));
         }
 
         // If the message wasn't already in the log, increment cycles
@@ -240,6 +248,8 @@ impl PbftLog {
             self.cycles += 1;
         }
         trace!("{}", self);
+
+        Ok(())
     }
 
     /// Adds a message the (back)log, based on the given `PbftHint`
@@ -261,7 +271,7 @@ impl PbftLog {
                 Err(PbftError::NotReadyForMessage)
             }
             PbftHint::PastMessage => {
-                self.add_message(msg, state);
+                self.add_message(msg, state)?;
                 Err(PbftError::NotReadyForMessage)
             }
             PbftHint::PresentMessage => Ok(()),
@@ -463,7 +473,7 @@ mod tests {
             get_peer_id(&cfg, 0),
         );
 
-        log.add_message(msg.clone(), &state);
+        log.add_message(msg.clone(), &state).unwrap();
 
         let gotten_msgs = log.get_messages_of_type_seq_view(&PbftMessageType::PrePrepare, 1, 0);
 
@@ -485,7 +495,7 @@ mod tests {
             get_peer_id(&cfg, 0),
             get_peer_id(&cfg, 0),
         );
-        log.add_message(msg.clone(), &state);
+        log.add_message(msg.clone(), &state).unwrap();
 
         assert_eq!(log.cycles, 1);
         assert!(!log.check_prepared(&msg.info(), 1 as u64).unwrap());
@@ -498,7 +508,7 @@ mod tests {
             get_peer_id(&cfg, 0),
             get_peer_id(&cfg, 0),
         );
-        log.add_message(msg.clone(), &state);
+        log.add_message(msg.clone(), &state).unwrap();
         assert!(!log.check_prepared(&msg.info(), 1 as u64).unwrap());
         assert!(!log.check_committable(&msg.info(), 1 as u64).unwrap());
 
@@ -511,7 +521,7 @@ mod tests {
                 get_peer_id(&cfg, 0),
             );
 
-            log.add_message(msg.clone(), &state);
+            log.add_message(msg.clone(), &state).unwrap();
             if peer < 2 {
                 assert!(!log.check_prepared(&msg.info(), 1 as u64).unwrap());
                 assert!(!log.check_committable(&msg.info(), 1 as u64).unwrap());
@@ -530,7 +540,7 @@ mod tests {
                 get_peer_id(&cfg, 0),
             );
 
-            log.add_message(msg.clone(), &state);
+            log.add_message(msg.clone(), &state).unwrap();
             if peer < 2 {
                 assert!(!log.check_committable(&msg.info(), 1 as u64).unwrap());
             } else {
@@ -565,7 +575,7 @@ mod tests {
                 get_peer_id(&cfg, 0),
                 get_peer_id(&cfg, 0),
             );
-            log.add_message(msg.clone(), &state);
+            log.add_message(msg.clone(), &state).unwrap();
 
             let msg = make_msg(
                 &PbftMessageType::PrePrepare,
@@ -574,7 +584,7 @@ mod tests {
                 get_peer_id(&cfg, 0),
                 get_peer_id(&cfg, 0),
             );
-            log.add_message(msg.clone(), &state);
+            log.add_message(msg.clone(), &state).unwrap();
 
             for peer in 0..4 {
                 let msg = make_msg(
@@ -585,7 +595,7 @@ mod tests {
                     get_peer_id(&cfg, 0),
                 );
 
-                log.add_message(msg.clone(), &state);
+                log.add_message(msg.clone(), &state).unwrap();
             }
 
             for peer in 0..4 {
@@ -597,7 +607,7 @@ mod tests {
                     get_peer_id(&cfg, 0),
                 );
 
-                log.add_message(msg.clone(), &state);
+                log.add_message(msg.clone(), &state).unwrap();
             }
         }
 
@@ -610,7 +620,7 @@ mod tests {
                 get_peer_id(&cfg, 0),
             );
 
-            log.add_message(msg.clone(), &state);
+            log.add_message(msg.clone(), &state).unwrap();
         }
 
         log.garbage_collect(4, 0);

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -167,7 +167,7 @@ impl PbftLog {
     }
 
     /// Get one message matching the type, view number, and sequence number
-    fn get_one_msg(
+    pub fn get_one_msg(
         &self,
         info: &PbftMessageInfo,
         msg_type: &PbftMessageType,

--- a/src/node.rs
+++ b/src/node.rs
@@ -98,11 +98,6 @@ impl PbftNode {
 
                 handlers::pre_prepare(state, &mut self.msg_log, &msg)?;
 
-                // NOTE: Putting log add here is necessary because on_peer_message gets
-                // called again inside of _broadcast_pbft_message
-                self.msg_log.add_message(msg.clone(), state)?;
-                state.switch_phase(PbftPhase::Preparing);
-
                 self.broadcast_pre_prepare(&msg, state)?;
             }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -207,7 +207,7 @@ impl PbftNode {
         state: &mut PbftState,
     ) -> Result<(), PbftError> {
         if state.phase == PbftPhase::Committing {
-            handlers::commit(state, &mut self.msg_log, &mut *self.service, msg)
+            handlers::commit(state, &mut *self.service, msg)
         } else {
             debug!(
                 "{}: Already committed block {:?}",
@@ -569,7 +569,6 @@ impl PbftNode {
         // having received a regular commit message.
         handlers::commit(
             state,
-            &mut self.msg_log,
             &mut *self.service,
             &messages[0].as_msg_type(PbftMessageType::Commit),
         )?;


### PR DESCRIPTION
Simplifies and corrects checked conditions in the PrePrepare and Commit phases; also updates the way the sequence number is tracked by basing it off of the current chain head.