### PR TITLE
Remove hinting and watermarks

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,9 @@ pub enum PbftError {
 
     /// The message should only come from the primary, but was sent by a secondary node
     NotFromPrimary,
+
+    /// Got a PrePrepare without a matching BlockNew
+    NoBlockNew,
 }
 
 impl Error for PbftError {
@@ -87,6 +90,7 @@ impl Error for PbftError {
             NoWorkingBlock => "NoWorkingBlock",
             NotReadyForMessage => "NotReadyForMessage",
             NotFromPrimary => "NotFromPrimary",
+            NoBlockNew => "NoBlockNew",
         }
     }
 }
@@ -124,6 +128,7 @@ impl fmt::Display for PbftError {
                 f,
                 "Message should be from primary, but was sent by secondary"
             ),
+            PbftError::NoBlockNew => write!(f, "Got a PrePrepare without a matching BlockNew"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,10 +44,6 @@ pub enum PbftError {
     /// The message is in a different view than this node is
     ViewMismatch(usize, usize),
 
-    /// The message has a sequence number that is not between watermarks
-    /// (message's sequence number, low watermark, high watermark)
-    InvalidSequenceNumber(usize, usize, usize),
-
     /// Internal PBFT error (description)
     InternalError(String),
 
@@ -82,7 +78,6 @@ impl Error for PbftError {
             BlockMismatch(_, _) => "BlockMismatch",
             MessageMismatch(_) => "MessageMismatch",
             ViewMismatch(_, _) => "ViewMismatch",
-            InvalidSequenceNumber(_, _, _) => "InvalidSequenceNumber",
             InternalError(_) => "InternalError",
             NodeNotFound => "NodeNotFound",
             WrongNumBlocks => "WrongNumBlocks",
@@ -107,11 +102,6 @@ impl fmt::Display for PbftError {
             ),
             PbftError::MessageMismatch(t) => write!(f, "{:?} message mismatch", t),
             PbftError::ViewMismatch(exp, got) => write!(f, "View mismatch: {} != {}", exp, got),
-            PbftError::InvalidSequenceNumber(got, low, high) => write!(
-                f,
-                "Invalid sequence number: {} is not in range [{},{})",
-                got, low, high
-            ),
             PbftError::BlockMismatch(exp, got) => write!(
                 f,
                 "{:?} != {:?}",

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -28,7 +28,7 @@ use sawtooth_sdk::consensus::engine::Block;
 
 use crate::config::PbftConfig;
 use crate::error::PbftError;
-use crate::message_type::{ParsedMessage, PbftHint, PbftMessageType};
+use crate::message_type::{ParsedMessage, PbftMessageType};
 use crate::protos::pbft_message::{PbftMessage, PbftMessageInfo};
 use crate::state::PbftState;
 
@@ -250,32 +250,6 @@ impl PbftLog {
         trace!("{}", self);
 
         Ok(())
-    }
-
-    /// Adds a message the (back)log, based on the given `PbftHint`
-    ///
-    /// Past messages are added to the general message log
-    /// Future messages are added to the backlog of messages to handle at a later time
-    /// Present messages are ignored, as they're generally added immediately after
-    /// this method is called by the calling code, except for `PrePrepare` messages
-    #[allow(clippy::ptr_arg)]
-    pub fn add_message_with_hint(
-        &mut self,
-        msg: ParsedMessage,
-        hint: &PbftHint,
-        state: &PbftState,
-    ) -> Result<(), PbftError> {
-        match hint {
-            PbftHint::FutureMessage => {
-                self.push_backlog(msg);
-                Err(PbftError::NotReadyForMessage)
-            }
-            PbftHint::PastMessage => {
-                self.add_message(msg, state)?;
-                Err(PbftError::NotReadyForMessage)
-            }
-            PbftHint::PresentMessage => Ok(()),
-        }
     }
 
     /// Obtain all messages from the log that match a given type and sequence_number

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -24,7 +24,6 @@ use std::fmt;
 
 use hex;
 use itertools::Itertools;
-use sawtooth_sdk::consensus::engine::Block;
 
 use crate::config::PbftConfig;
 use crate::error::PbftError;
@@ -60,9 +59,6 @@ pub struct PbftLog {
 
     /// Backlog of messages (from peers) with sender's ID
     backlog: VecDeque<ParsedMessage>,
-
-    /// Backlog of blocks (from BlockNews messages)
-    block_backlog: VecDeque<Block>,
 
     /// The most recent checkpoint that contains proof
     pub latest_stable_checkpoint: Option<PbftStableCheckpoint>,
@@ -108,7 +104,6 @@ impl PbftLog {
             high_water_mark: config.max_log_size,
             max_log_size: config.max_log_size,
             backlog: VecDeque::new(),
-            block_backlog: VecDeque::new(),
             latest_stable_checkpoint: None,
         }
     }
@@ -362,14 +357,6 @@ impl PbftLog {
 
     pub fn pop_backlog(&mut self) -> Option<ParsedMessage> {
         self.backlog.pop_front()
-    }
-
-    pub fn push_block_backlog(&mut self, msg: Block) {
-        self.block_backlog.push_back(msg);
-    }
-
-    pub fn pop_block_backlog(&mut self) -> Option<Block> {
-        self.block_backlog.pop_front()
     }
 }
 

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -214,19 +214,6 @@ impl ParsedMessage {
     }
 }
 
-/// Enum for showing the difference between future messages, present messages, and past messages.
-#[derive(Debug, PartialEq)]
-pub enum PbftHint {
-    /// A future message. The node is not ready to process it yet.
-    FutureMessage,
-
-    /// A past message. It's possible the node may still need it though, so it is added to the log.
-    PastMessage,
-
-    /// A present message. The node is ready to process this message immediately.
-    PresentMessage,
-}
-
 // Messages related to PBFT consensus
 #[derive(Debug, PartialEq, PartialOrd)]
 pub enum PbftMessageType {

--- a/src/node.rs
+++ b/src/node.rs
@@ -241,10 +241,13 @@ impl PbftNode {
 
     #[allow(clippy::ptr_arg)]
     fn check_if_checkpoint_started(&mut self, msg: &ParsedMessage, state: &mut PbftState) -> bool {
-        // Not ready to receive checkpoint yet; only acceptable in NotStarted
-        if state.phase != PbftPhase::NotStarted {
+        // Not ready to receive checkpoint yet; only acceptable in PrePreparing
+        if state.phase != PbftPhase::PrePreparing {
             self.msg_log.push_backlog(msg.clone());
-            debug!("{}: Not in NotStarted; not handling checkpoint yet", state);
+            debug!(
+                "{}: Not in PrePreparing; not handling checkpoint yet",
+                state
+            );
             false
         } else {
             true
@@ -658,23 +661,14 @@ impl PbftNode {
             return Ok(());
         }
 
-        if block.block_num > head.block_num + 1
-            || state.switch_phase(PbftPhase::PrePreparing).is_none()
-        {
-            debug!(
-                "{}: Not ready for block {}, pushing to backlog",
-                state,
-                &hex::encode(block.block_id.clone())[..6]
-            );
-            self.msg_log.push_block_backlog(block.clone());
-            return Ok(());
-        }
-
         self.msg_log
             .add_message(ParsedMessage::from_pbft_message(msg), state)?;
-        state.working_block = WorkingBlockOption::TentativeWorkingBlock(block.block_id);
-        state.idle_timeout.stop();
-        state.commit_timeout.start();
+
+        if block.block_num == head.block_num + 1 {
+            state.working_block = WorkingBlockOption::TentativeWorkingBlock(block.block_id);
+            state.idle_timeout.stop();
+            state.commit_timeout.start();
+        }
 
         if state.is_primary() {
             let s = state.seq_num;
@@ -686,9 +680,9 @@ impl PbftNode {
     /// Handle a `BlockCommit` update from the Validator
     /// Since the block was successfully committed, the primary is not faulty and the view change
     /// timer can be stopped. If this node is a primary, then initialize a new block. Both node
-    /// roles transition back to the `NotStarted` phase. If this node is at a checkpoint after the
-    /// previously committed block (`checkpoint_period` blocks have been committed since the last
-    /// checkpoint), then start a checkpoint.
+    /// roles transition back to the `PrePreparing` phase. If this node is at a checkpoint after
+    /// the previously committed block (`checkpoint_period` blocks have been committed since the
+    /// last checkpoint), then start a checkpoint.
     pub fn on_block_commit(
         &mut self,
         block_id: BlockId,
@@ -707,7 +701,7 @@ impl PbftNode {
                     .unwrap_or_else(|err| error!("Couldn't initialize block: {}", err));
             }
 
-            state.switch_phase(PbftPhase::NotStarted);
+            state.switch_phase(PbftPhase::PrePreparing);
             state.seq_num += 1;
 
             // Start a view change if we need to force one for fairness or if membership changed
@@ -715,7 +709,7 @@ impl PbftNode {
                 self.force_view_change(state);
             }
 
-            // Start a checkpoint in NotStarted, if we're at one
+            // Start a checkpoint in PrePreparing, if we're at one
             if self.msg_log.at_checkpoint() {
                 self.start_checkpoint(state)?;
             }
@@ -822,7 +816,7 @@ impl PbftNode {
         // Only the primary takes care of this, and we try publishing a block
         // on every engine loop, even if it's not yet ready. This isn't an error,
         // so just return Ok(()).
-        if !state.is_primary() || state.phase != PbftPhase::NotStarted {
+        if !state.is_primary() || state.phase != PbftPhase::PrePreparing {
             return Ok(());
         }
 
@@ -906,12 +900,6 @@ impl PbftNode {
         if let Some(msg) = self.msg_log.pop_backlog() {
             debug!("{}: Popping message from backlog", state);
             peer_res = self.on_peer_message(msg, state);
-        }
-        if state.mode == PbftMode::Normal && state.phase == PbftPhase::NotStarted {
-            if let Some(msg) = self.msg_log.pop_block_backlog() {
-                debug!("{}: Popping BlockNew from backlog", state);
-                self.on_block_new(msg, state)?;
-            }
         }
         peer_res
     }
@@ -1342,7 +1330,7 @@ mod tests {
 
         assert_eq!(state.id, vec![0]);
         assert_eq!(state.view, 0);
-        assert_eq!(state.phase, PbftPhase::NotStarted);
+        assert_eq!(state.phase, PbftPhase::PrePreparing);
         assert_eq!(state.mode, PbftMode::Normal);
         assert_eq!(state.pre_checkpoint_mode, PbftMode::Normal);
         assert_eq!(state.peer_ids, (0..4).map(|i| vec![i]).collect::<Vec<_>>());
@@ -1457,7 +1445,7 @@ mod tests {
 
         node.on_block_new(block, &mut state).unwrap();
 
-        assert_eq!(state.phase, PbftPhase::NotStarted);
+        assert_eq!(state.phase, PbftPhase::PrePreparing);
         assert_eq!(state.working_block, WorkingBlockOption::NoWorkingBlock);
     }
 
@@ -1485,7 +1473,7 @@ mod tests {
         assert_eq!(state0.seq_num, 1);
         node.on_block_commit(mock_block_id(1), &mut state0)
             .unwrap_or_else(handle_pbft_err);
-        assert_eq!(state0.phase, PbftPhase::NotStarted);
+        assert_eq!(state0.phase, PbftPhase::PrePreparing);
         assert_eq!(state0.seq_num, 2);
     }
 
@@ -1541,7 +1529,7 @@ mod tests {
 
         // Spoof the `commit_blocks()` call
         assert!(node1.on_block_commit(mock_block_id(1), &mut state1).is_ok());
-        assert_eq!(state1.phase, PbftPhase::NotStarted);
+        assert_eq!(state1.phase, PbftPhase::PrePreparing);
 
         // Make sure the block was actually committed
         let mut f = File::open(BLOCK_FILE).unwrap();
@@ -1663,7 +1651,7 @@ mod tests {
                 .unwrap();
         }
 
-        state0.phase = PbftPhase::NotStarted;
+        state0.phase = PbftPhase::PrePreparing;
         state0.working_block = WorkingBlockOption::WorkingBlock(pbft_block0.clone());
 
         node0.try_publish(&mut state0).unwrap();


### PR DESCRIPTION
Removes the hinting mechanism since it prevents the node from adding
valid messages to the log unnecessarily; as long as a message is valid
and follows the rules necessary for being added to the log, we do not
need to backlog messages until we are at the right sequence number or
phase.

Removes the water marking component of PBFT since it is not necessary.
This mechanism was designed to prevent a primary for selecting a
sequence number that was so high it exhausted the space of sequence
numbers. Because the primary does not decide the sequence number (it is
determined by the block number), it can't violate this anyway.