### PR TITLE
Remove checkpointing

### DIFF
--- a/protos/pbft_message.proto
+++ b/protos/pbft_message.proto
@@ -43,7 +43,7 @@ message PbftMessageInfo {
 }
 
 
-// A generic PBFT message (PrePrepare, Prepare, Commit, Checkpoint)
+// A generic PBFT message (PrePrepare, Prepare, Commit)
 message PbftMessage {
   // Message information
   PbftMessageInfo info = 1;
@@ -58,9 +58,9 @@ message PbftViewChange {
   // Message information
   PbftMessageInfo info = 1;
 
-  // Set of `2f + 1` checkpoint messages, proving correctness of stable
-  // checkpoint mentioned in info's `sequence_number`
-  repeated PbftMessage checkpoint_messages = 2;
+  // Consensus seal proving the correctness of the block committed at the
+  // sequence number specified in the message info
+  PbftSeal seal = 2;
 }
 
 message PbftSignedCommitVote {

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,9 +51,6 @@ pub struct PbftConfig {
     /// How many blocks to commit before forcing a view change
     pub forced_view_change_period: u64,
 
-    /// How many requests in between each checkpoint
-    pub checkpoint_period: u64,
-
     /// How large the PbftLog is allowed to get
     pub max_log_size: u64,
 
@@ -70,7 +67,6 @@ impl PbftConfig {
             commit_timeout: Duration::from_millis(4000),
             idle_timeout: Duration::from_millis(30_000),
             forced_view_change_period: 30,
-            checkpoint_period: 100,
             max_log_size: 1000,
             storage: "memory".into(),
         }
@@ -82,7 +78,6 @@ impl PbftConfig {
 /// Configuration loads the following settings:
 /// + `sawtooth.consensus.pbft.peers` (required)
 /// + `sawtooth.consensus.pbft.block_duration` (optional, default 200 ms)
-/// + `sawtooth.consensus.pbft.checkpoint_period` (optional, default 10 ms)
 /// + `sawtooth.consensus.pbft.commit_timeout` (optional, default 4s)
 /// + `sawtooth.consensus.pbft.idle_timeout` (optional, default 30s)
 /// + `sawtooth.consensus.pbft.forced_view_change_period` (optional, default 30 blocks)
@@ -103,7 +98,6 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
             vec![
                 String::from("sawtooth.consensus.pbft.peers"),
                 String::from("sawtooth.consensus.pbft.block_duration"),
-                String::from("sawtooth.consensus.pbft.checkpoint_period"),
                 String::from("sawtooth.consensus.pbft.commit_timeout"),
                 String::from("sawtooth.consensus.pbft.idle_timeout"),
                 String::from("sawtooth.consensus.pbft.forced_view_change_period"),
@@ -151,11 +145,6 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
         &settings,
         &mut config.forced_view_change_period,
         "sawtooth.consensus.pbft.forced_view_change_period",
-    );
-    merge_setting_if_set(
-        &settings,
-        &mut config.checkpoint_period,
-        "sawtooth.consensus.pbft.checkpoint_period",
     );
     merge_setting_if_set(
         &settings,

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,7 +149,7 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
     // Get various integer constants
     merge_setting_if_set(
         &settings,
-        &mut config.checkpoint_period,
+        &mut config.forced_view_change_period,
         "sawtooth.consensus.pbft.forced_view_change_period",
     );
     merge_setting_if_set(

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,9 @@ pub enum PbftError {
     /// Too many or too few messages recieved so far (expected, got)
     WrongNumMessages(PbftMessageType, usize, usize),
 
+    /// Too many or too few consenus seals found (expected, got)
+    WrongNumSeals(usize, usize),
+
     /// The block in the message doesn't match the one this node was expecting
     BlockMismatch(PbftBlock, PbftBlock),
 
@@ -75,6 +78,7 @@ impl Error for PbftError {
         match self {
             SerializationError(_) => "SerializationError",
             WrongNumMessages(_, _, _) => "WrongNumMessages",
+            WrongNumSeals(_, _) => "WrongNumSeals",
             BlockMismatch(_, _) => "BlockMismatch",
             MessageMismatch(_) => "MessageMismatch",
             ViewMismatch(_, _) => "ViewMismatch",
@@ -99,6 +103,11 @@ impl fmt::Display for PbftError {
                 f,
                 "Wrong number of {:?} messages in this sequence (expected {}, got {})",
                 t, exp, got
+            ),
+            PbftError::WrongNumSeals(exp, got) => write!(
+                f,
+                "Wrong number of consensus seals found (expected {}, got {})",
+                exp, got
             ),
             PbftError::MessageMismatch(t) => write!(f, "{:?} message mismatch", t),
             PbftError::ViewMismatch(exp, got) => write!(f, "View mismatch: {} != {}", exp, got),

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,9 @@ pub enum PbftError {
 
     /// The message should only come from the primary, but was sent by a secondary node
     NotFromPrimary,
+
+    /// Got a PrePrepare without a matching BlockNew
+    NoBlockNew,
 }
 
 impl Error for PbftError {
@@ -87,6 +90,7 @@ impl Error for PbftError {
             NoWorkingBlock => "NoWorkingBlock",
             NotReadyForMessage => "NotReadyForMessage",
             NotFromPrimary => "NotFromPrimary",
+            NoBlockNew => "NoBlockNew",
         }
     }
 }
@@ -124,6 +128,7 @@ impl fmt::Display for PbftError {
                 f,
                 "Message should be from primary, but was sent by secondary"
             ),
+            PbftError::NoBlockNew => write!(f, "Got a PrePrepare without a matching BlockNew"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,10 +44,6 @@ pub enum PbftError {
     /// The message is in a different view than this node is
     ViewMismatch(usize, usize),
 
-    /// The message has a sequence number that is not between watermarks
-    /// (message's sequence number, low watermark, high watermark)
-    InvalidSequenceNumber(usize, usize, usize),
-
     /// Internal PBFT error (description)
     InternalError(String),
 
@@ -82,7 +78,6 @@ impl Error for PbftError {
             BlockMismatch(_, _) => "BlockMismatch",
             MessageMismatch(_) => "MessageMismatch",
             ViewMismatch(_, _) => "ViewMismatch",
-            InvalidSequenceNumber(_, _, _) => "InvalidSequenceNumber",
             InternalError(_) => "InternalError",
             NodeNotFound => "NodeNotFound",
             WrongNumBlocks => "WrongNumBlocks",
@@ -107,11 +102,6 @@ impl fmt::Display for PbftError {
             ),
             PbftError::MessageMismatch(t) => write!(f, "{:?} message mismatch", t),
             PbftError::ViewMismatch(exp, got) => write!(f, "View mismatch: {} != {}", exp, got),
-            PbftError::InvalidSequenceNumber(got, low, high) => write!(
-                f,
-                "Invalid sequence number: {} is not in range [{},{})",
-                got, low, high
-            ),
             PbftError::BlockMismatch(exp, got) => write!(
                 f,
                 "{:?} != {:?}",

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -27,9 +27,12 @@ use std::hash::{Hash, Hasher};
 use hex;
 
 use crate::message_type::PbftMessageType;
-use crate::protos::pbft_message::{PbftBlock, PbftMessage, PbftMessageInfo, PbftViewChange};
+use crate::protos::pbft_message::{
+    PbftBlock, PbftMessage, PbftMessageInfo, PbftSeal, PbftSignedCommitVote, PbftViewChange,
+};
 
 impl Eq for PbftMessage {}
+impl Eq for PbftSeal {}
 impl Eq for PbftViewChange {}
 
 impl Hash for PbftMessageInfo {
@@ -57,13 +60,28 @@ impl Hash for PbftMessage {
     }
 }
 
+impl Hash for PbftSeal {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.get_previous_id().hash(state);
+        self.get_summary().hash(state);
+        for vote in self.get_previous_commit_votes() {
+            vote.hash(state);
+        }
+    }
+}
+
+impl Hash for PbftSignedCommitVote {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.get_header_bytes().hash(state);
+        self.get_header_signature().hash(state);
+        self.get_message_bytes().hash(state);
+    }
+}
+
 impl Hash for PbftViewChange {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.get_info().hash(state);
-        for msg in self.get_checkpoint_messages().iter() {
-            msg.get_info().hash(state);
-            msg.get_block().hash(state);
-        }
+        self.get_seal().hash(state);
     }
 }
 

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -28,7 +28,7 @@ use sawtooth_sdk::consensus::engine::Block;
 
 use crate::config::PbftConfig;
 use crate::error::PbftError;
-use crate::message_type::{ParsedMessage, PbftHint, PbftMessageType};
+use crate::message_type::{ParsedMessage, PbftMessageType};
 use crate::protos::pbft_message::{PbftMessage, PbftMessageInfo};
 use crate::state::PbftState;
 
@@ -250,32 +250,6 @@ impl PbftLog {
         trace!("{}", self);
 
         Ok(())
-    }
-
-    /// Adds a message the (back)log, based on the given `PbftHint`
-    ///
-    /// Past messages are added to the general message log
-    /// Future messages are added to the backlog of messages to handle at a later time
-    /// Present messages are ignored, as they're generally added immediately after
-    /// this method is called by the calling code, except for `PrePrepare` messages
-    #[allow(clippy::ptr_arg)]
-    pub fn add_message_with_hint(
-        &mut self,
-        msg: ParsedMessage,
-        hint: &PbftHint,
-        state: &PbftState,
-    ) -> Result<(), PbftError> {
-        match hint {
-            PbftHint::FutureMessage => {
-                self.push_backlog(msg);
-                Err(PbftError::NotReadyForMessage)
-            }
-            PbftHint::PastMessage => {
-                self.add_message(msg, state)?;
-                Err(PbftError::NotReadyForMessage)
-            }
-            PbftHint::PresentMessage => Ok(()),
-        }
     }
 
     /// Obtain all messages from the log that match a given type and sequence_number

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -24,7 +24,6 @@ use std::fmt;
 
 use hex;
 use itertools::Itertools;
-use sawtooth_sdk::consensus::engine::Block;
 
 use crate::config::PbftConfig;
 use crate::error::PbftError;
@@ -60,9 +59,6 @@ pub struct PbftLog {
 
     /// Backlog of messages (from peers) with sender's ID
     backlog: VecDeque<ParsedMessage>,
-
-    /// Backlog of blocks (from BlockNews messages)
-    block_backlog: VecDeque<Block>,
 
     /// The most recent checkpoint that contains proof
     pub latest_stable_checkpoint: Option<PbftStableCheckpoint>,
@@ -108,7 +104,6 @@ impl PbftLog {
             high_water_mark: config.max_log_size,
             max_log_size: config.max_log_size,
             backlog: VecDeque::new(),
-            block_backlog: VecDeque::new(),
             latest_stable_checkpoint: None,
         }
     }
@@ -362,14 +357,6 @@ impl PbftLog {
 
     pub fn pop_backlog(&mut self) -> Option<ParsedMessage> {
         self.backlog.pop_front()
-    }
-
-    pub fn push_block_backlog(&mut self, msg: Block) {
-        self.block_backlog.push_back(msg);
-    }
-
-    pub fn pop_block_backlog(&mut self) -> Option<Block> {
-        self.block_backlog.pop_front()
     }
 }
 

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -224,7 +224,6 @@ pub enum PbftMessageType {
 
     /// Auxiliary PBFT messages
     BlockNew,
-    Checkpoint,
     ViewChange,
 
     Unset,
@@ -237,7 +236,6 @@ impl fmt::Display for PbftMessageType {
             PbftMessageType::Prepare => "Pr",
             PbftMessageType::Commit => "Co",
             PbftMessageType::BlockNew => "BN",
-            PbftMessageType::Checkpoint => "CP",
             PbftMessageType::ViewChange => "VC",
             PbftMessageType::Unset => "Un",
         };
@@ -265,7 +263,6 @@ impl<'a> From<&'a str> for PbftMessageType {
             "Commit" => PbftMessageType::Commit,
             "BlockNew" => PbftMessageType::BlockNew,
             "ViewChange" => PbftMessageType::ViewChange,
-            "Checkpoint" => PbftMessageType::Checkpoint,
             _ => {
                 warn!("Unhandled PBFT message type: {}", s);
                 PbftMessageType::Unset

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -214,19 +214,6 @@ impl ParsedMessage {
     }
 }
 
-/// Enum for showing the difference between future messages, present messages, and past messages.
-#[derive(Debug, PartialEq)]
-pub enum PbftHint {
-    /// A future message. The node is not ready to process it yet.
-    FutureMessage,
-
-    /// A past message. It's possible the node may still need it though, so it is added to the log.
-    PastMessage,
-
-    /// A present message. The node is ready to process this message immediately.
-    PresentMessage,
-}
-
 // Messages related to PBFT consensus
 #[derive(Debug, PartialEq, PartialOrd)]
 pub enum PbftMessageType {

--- a/src/node.rs
+++ b/src/node.rs
@@ -241,10 +241,13 @@ impl PbftNode {
 
     #[allow(clippy::ptr_arg)]
     fn check_if_checkpoint_started(&mut self, msg: &ParsedMessage, state: &mut PbftState) -> bool {
-        // Not ready to receive checkpoint yet; only acceptable in NotStarted
-        if state.phase != PbftPhase::NotStarted {
+        // Not ready to receive checkpoint yet; only acceptable in PrePreparing
+        if state.phase != PbftPhase::PrePreparing {
             self.msg_log.push_backlog(msg.clone());
-            debug!("{}: Not in NotStarted; not handling checkpoint yet", state);
+            debug!(
+                "{}: Not in PrePreparing; not handling checkpoint yet",
+                state
+            );
             false
         } else {
             true
@@ -658,23 +661,14 @@ impl PbftNode {
             return Ok(());
         }
 
-        if block.block_num > head.block_num + 1
-            || state.switch_phase(PbftPhase::PrePreparing).is_none()
-        {
-            debug!(
-                "{}: Not ready for block {}, pushing to backlog",
-                state,
-                &hex::encode(block.block_id.clone())[..6]
-            );
-            self.msg_log.push_block_backlog(block.clone());
-            return Ok(());
-        }
-
         self.msg_log
             .add_message(ParsedMessage::from_pbft_message(msg), state)?;
-        state.working_block = WorkingBlockOption::TentativeWorkingBlock(block.block_id);
-        state.idle_timeout.stop();
-        state.commit_timeout.start();
+
+        if block.block_num == head.block_num + 1 {
+            state.working_block = WorkingBlockOption::TentativeWorkingBlock(block.block_id);
+            state.idle_timeout.stop();
+            state.commit_timeout.start();
+        }
 
         if state.is_primary() {
             let s = state.seq_num;
@@ -686,9 +680,9 @@ impl PbftNode {
     /// Handle a `BlockCommit` update from the Validator
     /// Since the block was successfully committed, the primary is not faulty and the view change
     /// timer can be stopped. If this node is a primary, then initialize a new block. Both node
-    /// roles transition back to the `NotStarted` phase. If this node is at a checkpoint after the
-    /// previously committed block (`checkpoint_period` blocks have been committed since the last
-    /// checkpoint), then start a checkpoint.
+    /// roles transition back to the `PrePreparing` phase. If this node is at a checkpoint after
+    /// the previously committed block (`checkpoint_period` blocks have been committed since the
+    /// last checkpoint), then start a checkpoint.
     pub fn on_block_commit(
         &mut self,
         block_id: BlockId,
@@ -707,7 +701,7 @@ impl PbftNode {
                     .unwrap_or_else(|err| error!("Couldn't initialize block: {}", err));
             }
 
-            state.switch_phase(PbftPhase::NotStarted);
+            state.switch_phase(PbftPhase::PrePreparing);
             state.seq_num += 1;
 
             // Start a view change if we need to force one for fairness or if membership changed
@@ -715,7 +709,7 @@ impl PbftNode {
                 self.force_view_change(state);
             }
 
-            // Start a checkpoint in NotStarted, if we're at one
+            // Start a checkpoint in PrePreparing, if we're at one
             if self.msg_log.at_checkpoint() {
                 self.start_checkpoint(state)?;
             }
@@ -822,7 +816,7 @@ impl PbftNode {
         // Only the primary takes care of this, and we try publishing a block
         // on every engine loop, even if it's not yet ready. This isn't an error,
         // so just return Ok(()).
-        if !state.is_primary() || state.phase != PbftPhase::NotStarted {
+        if !state.is_primary() || state.phase != PbftPhase::PrePreparing {
             return Ok(());
         }
 
@@ -906,12 +900,6 @@ impl PbftNode {
         if let Some(msg) = self.msg_log.pop_backlog() {
             debug!("{}: Popping message from backlog", state);
             peer_res = self.on_peer_message(msg, state);
-        }
-        if state.mode == PbftMode::Normal && state.phase == PbftPhase::NotStarted {
-            if let Some(msg) = self.msg_log.pop_block_backlog() {
-                debug!("{}: Popping BlockNew from backlog", state);
-                self.on_block_new(msg, state)?;
-            }
         }
         peer_res
     }
@@ -1342,7 +1330,7 @@ mod tests {
 
         assert_eq!(state.id, vec![0]);
         assert_eq!(state.view, 0);
-        assert_eq!(state.phase, PbftPhase::NotStarted);
+        assert_eq!(state.phase, PbftPhase::PrePreparing);
         assert_eq!(state.mode, PbftMode::Normal);
         assert_eq!(state.pre_checkpoint_mode, PbftMode::Normal);
         assert_eq!(state.peer_ids, (0..4).map(|i| vec![i]).collect::<Vec<_>>());
@@ -1457,7 +1445,7 @@ mod tests {
 
         node.on_block_new(block, &mut state).unwrap();
 
-        assert_eq!(state.phase, PbftPhase::NotStarted);
+        assert_eq!(state.phase, PbftPhase::PrePreparing);
         assert_eq!(state.working_block, WorkingBlockOption::NoWorkingBlock);
     }
 
@@ -1485,7 +1473,7 @@ mod tests {
         assert_eq!(state0.seq_num, 1);
         node.on_block_commit(mock_block_id(1), &mut state0)
             .unwrap_or_else(handle_pbft_err);
-        assert_eq!(state0.phase, PbftPhase::NotStarted);
+        assert_eq!(state0.phase, PbftPhase::PrePreparing);
         assert_eq!(state0.seq_num, 2);
     }
 
@@ -1541,7 +1529,7 @@ mod tests {
 
         // Spoof the `commit_blocks()` call
         assert!(node1.on_block_commit(mock_block_id(1), &mut state1).is_ok());
-        assert_eq!(state1.phase, PbftPhase::NotStarted);
+        assert_eq!(state1.phase, PbftPhase::PrePreparing);
 
         // Make sure the block was actually committed
         let mut f = File::open(BLOCK_FILE).unwrap();
@@ -1663,7 +1651,7 @@ mod tests {
                 .unwrap();
         }
 
-        state0.phase = PbftPhase::NotStarted;
+        state0.phase = PbftPhase::PrePreparing;
         state0.working_block = WorkingBlockOption::WorkingBlock(pbft_block0.clone());
 
         node0.try_publish(&mut state0).unwrap();

--- a/src/state.rs
+++ b/src/state.rs
@@ -50,7 +50,6 @@ pub enum PbftPhase {
 pub enum PbftMode {
     Normal,
     ViewChanging,
-    Checkpointing,
 }
 
 impl fmt::Display for PbftState {
@@ -58,7 +57,6 @@ impl fmt::Display for PbftState {
         let ast = if self.is_primary() { "*" } else { " " };
         let mode = match self.mode {
             PbftMode::Normal => "N",
-            PbftMode::Checkpointing => "C",
             PbftMode::ViewChanging => "V",
         };
 
@@ -135,9 +133,8 @@ pub struct PbftState {
     /// Is this node primary or secondary?
     role: PbftNodeRole,
 
-    /// Normal operation, view change, or checkpointing. Previous mode is stored when checkpointing
+    /// Normal operation or view changing
     pub mode: PbftMode,
-    pub pre_checkpoint_mode: PbftMode,
 
     /// Map of peers in the network, including ourselves
     pub peer_ids: Vec<PeerId>,
@@ -183,7 +180,6 @@ impl PbftState {
                 PbftNodeRole::Secondary
             },
             mode: PbftMode::Normal,
-            pre_checkpoint_mode: PbftMode::Normal,
             f,
             peer_ids: config.peers.clone(),
             commit_timeout: Timeout::new(config.commit_timeout),

--- a/tests/client.yaml
+++ b/tests/client.yaml
@@ -45,7 +45,6 @@ services:
           sawtooth.consensus.algorithm.version=0.1 \
           sawtooth.consensus.pbft.peers=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
           sawtooth.consensus.pbft.block_duration=100 \
-          sawtooth.consensus.pbft.checkpoint_period=10 \
           sawtooth.consensus.pbft.view_change_timeout=4000 \
           sawtooth.consensus.pbft.message_timeout=10 \
           sawtooth.consensus.pbft.max_log_size=1000 \

--- a/tests/grafana.yaml
+++ b/tests/grafana.yaml
@@ -71,7 +71,6 @@ services:
           sawtooth.consensus.algorithm.version=0.1 \
           sawtooth.consensus.pbft.peers=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
           sawtooth.consensus.pbft.block_duration=100 \
-          sawtooth.consensus.pbft.checkpoint_period=10 \
           sawtooth.consensus.pbft.view_change_timeout=4000 \
           sawtooth.consensus.pbft.message_timeout=10 \
           sawtooth.consensus.pbft.max_log_size=1000 \

--- a/tests/test_liveness.yaml
+++ b/tests/test_liveness.yaml
@@ -74,7 +74,6 @@ services:
           sawtooth.consensus.algorithm.version=0.1.0 \
           sawtooth.consensus.pbft.peers=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
           sawtooth.consensus.pbft.block_duration=100 \
-          sawtooth.consensus.pbft.checkpoint_period=10 \
           sawtooth.consensus.pbft.view_change_timeout=4000 \
           sawtooth.consensus.pbft.message_timeout=10 \
           sawtooth.consensus.pbft.max_log_size=1000 \


### PR DESCRIPTION
Removes the checkpointing procedure and all of its associated code. This
is no longer needed with the consensus seal and the guarantees that are
provided by the state management of the blockchain. Because the
blockchain stores all state history and each block is verified by a
consensus seal that consists of PBFT messages that prove the block
commit, we are never truly garbage collecting; the blockchain will
always have these messages and state changes. This makes checkpointing
unnecessary.

The following is a summary of the changes that are made by this shift:
- When a seal is verified, it's stored in the log for potential use in a
view change message
- If a view change is required, the seal for the last committed block is
included in the view change message as the equivalent to the proof of
the last stable checkpoint.
- Consensus seals are garbage collected after each block is committed.
Once a block commits we only keep the last valid consensus seal, since
that's all we need to provide for a view change message.
- Garbage collection now happens once the number of messages in the log
is greater than or equal to the value specified in the `max_log_size`
configuration variable.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

Based on #65 