### PR TITLE
 Replace idle and commit timeouts with one timeout

### DIFF
--- a/protos/pbft_message.proto
+++ b/protos/pbft_message.proto
@@ -43,7 +43,7 @@ message PbftMessageInfo {
 }
 
 
-// A generic PBFT message (PrePrepare, Prepare, Commit, Checkpoint)
+// A generic PBFT message (PrePrepare, Prepare, Commit)
 message PbftMessage {
   // Message information
   PbftMessageInfo info = 1;
@@ -58,9 +58,9 @@ message PbftViewChange {
   // Message information
   PbftMessageInfo info = 1;
 
-  // Set of `2f + 1` checkpoint messages, proving correctness of stable
-  // checkpoint mentioned in info's `sequence_number`
-  repeated PbftMessage checkpoint_messages = 2;
+  // Consensus seal proving the correctness of the block committed at the
+  // sequence number specified in the message info
+  PbftSeal seal = 2;
 }
 
 message PbftSignedCommitVote {

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,7 +60,7 @@ impl PbftConfig {
             peers: Vec::new(),
             block_duration: Duration::from_millis(200),
             message_timeout: Duration::from_millis(10),
-            faulty_primary_timeout: Duration::from_millis(30_000),
+            faulty_primary_timeout: Duration::from_secs(30),
             forced_view_change_period: 30,
             max_log_size: 1000,
             storage: "memory".into(),
@@ -117,7 +117,7 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
         &mut config.message_timeout,
         "sawtooth.consensus.pbft.message_timeout",
     );
-    merge_millis_setting_if_set(
+    merge_secs_setting_if_set(
         &settings,
         &mut config.faulty_primary_timeout,
         "sawtooth.consensus.pbft.faulty_primary_timeout",
@@ -165,6 +165,19 @@ fn merge_setting_if_set_and_map<U, F, T>(
             *setting_field = map(setting_value);
         }
     }
+}
+
+fn merge_secs_setting_if_set(
+    settings_map: &HashMap<String, String>,
+    setting_field: &mut Duration,
+    setting_key: &str,
+) {
+    merge_setting_if_set_and_map(
+        settings_map,
+        setting_field,
+        setting_key,
+        Duration::from_secs,
+    )
 }
 
 fn merge_millis_setting_if_set(

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,9 +51,6 @@ pub struct PbftConfig {
     /// How many blocks to commit before forcing a view change
     pub forced_view_change_period: u64,
 
-    /// How many requests in between each checkpoint
-    pub checkpoint_period: u64,
-
     /// How large the PbftLog is allowed to get
     pub max_log_size: u64,
 
@@ -70,7 +67,6 @@ impl PbftConfig {
             commit_timeout: Duration::from_millis(4000),
             idle_timeout: Duration::from_millis(30_000),
             forced_view_change_period: 30,
-            checkpoint_period: 100,
             max_log_size: 1000,
             storage: "memory".into(),
         }
@@ -82,7 +78,6 @@ impl PbftConfig {
 /// Configuration loads the following settings:
 /// + `sawtooth.consensus.pbft.peers` (required)
 /// + `sawtooth.consensus.pbft.block_duration` (optional, default 200 ms)
-/// + `sawtooth.consensus.pbft.checkpoint_period` (optional, default 10 ms)
 /// + `sawtooth.consensus.pbft.commit_timeout` (optional, default 4s)
 /// + `sawtooth.consensus.pbft.idle_timeout` (optional, default 30s)
 /// + `sawtooth.consensus.pbft.forced_view_change_period` (optional, default 30 blocks)
@@ -103,7 +98,6 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
             vec![
                 String::from("sawtooth.consensus.pbft.peers"),
                 String::from("sawtooth.consensus.pbft.block_duration"),
-                String::from("sawtooth.consensus.pbft.checkpoint_period"),
                 String::from("sawtooth.consensus.pbft.commit_timeout"),
                 String::from("sawtooth.consensus.pbft.idle_timeout"),
                 String::from("sawtooth.consensus.pbft.forced_view_change_period"),
@@ -151,11 +145,6 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
         &settings,
         &mut config.forced_view_change_period,
         "sawtooth.consensus.pbft.forced_view_change_period",
-    );
-    merge_setting_if_set(
-        &settings,
-        &mut config.checkpoint_period,
-        "sawtooth.consensus.pbft.checkpoint_period",
     );
     merge_setting_if_set(
         &settings,

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,7 +149,7 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
     // Get various integer constants
     merge_setting_if_set(
         &settings,
-        &mut config.checkpoint_period,
+        &mut config.forced_view_change_period,
         "sawtooth.consensus.pbft.forced_view_change_period",
     );
     merge_setting_if_set(

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,13 +40,9 @@ pub struct PbftConfig {
     /// How long to wait for a message to arrive
     pub message_timeout: Duration,
 
-    /// How long to wait to initiate a ViewChange if we suspect the primary's faulty
+    /// How long to wait for the next BlockNew + PrePrepare before determining primary is faulty
     /// Should be longer than block_duration
-    pub commit_timeout: Duration,
-
-    /// How long to wait to initiate a ViewChange between a block being committed and a new block
-    /// being proposed.
-    pub idle_timeout: Duration,
+    pub faulty_primary_timeout: Duration,
 
     /// How many blocks to commit before forcing a view change
     pub forced_view_change_period: u64,
@@ -64,8 +60,7 @@ impl PbftConfig {
             peers: Vec::new(),
             block_duration: Duration::from_millis(200),
             message_timeout: Duration::from_millis(10),
-            commit_timeout: Duration::from_millis(4000),
-            idle_timeout: Duration::from_millis(30_000),
+            faulty_primary_timeout: Duration::from_millis(30_000),
             forced_view_change_period: 30,
             max_log_size: 1000,
             storage: "memory".into(),
@@ -78,8 +73,7 @@ impl PbftConfig {
 /// Configuration loads the following settings:
 /// + `sawtooth.consensus.pbft.peers` (required)
 /// + `sawtooth.consensus.pbft.block_duration` (optional, default 200 ms)
-/// + `sawtooth.consensus.pbft.commit_timeout` (optional, default 4s)
-/// + `sawtooth.consensus.pbft.idle_timeout` (optional, default 30s)
+/// + `sawtooth.consensus.pbft.faulty_primary_timeout` (optional, default 30s)
 /// + `sawtooth.consensus.pbft.forced_view_change_period` (optional, default 30 blocks)
 /// + `sawtooth.consensus.pbft.message_timeout` (optional, default 100 blocks)
 /// + `sawtooth.consensus.pbft.max_log_size` (optional, default 1000 messages)
@@ -98,8 +92,7 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
             vec![
                 String::from("sawtooth.consensus.pbft.peers"),
                 String::from("sawtooth.consensus.pbft.block_duration"),
-                String::from("sawtooth.consensus.pbft.commit_timeout"),
-                String::from("sawtooth.consensus.pbft.idle_timeout"),
+                String::from("sawtooth.consensus.pbft.faulty_primary_timeout"),
                 String::from("sawtooth.consensus.pbft.forced_view_change_period"),
                 String::from("sawtooth.consensus.pbft.message_timeout"),
                 String::from("sawtooth.consensus.pbft.max_log_size"),
@@ -126,17 +119,12 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
     );
     merge_millis_setting_if_set(
         &settings,
-        &mut config.commit_timeout,
-        "sawtooth.consensus.pbft.commit_timeout",
-    );
-    merge_millis_setting_if_set(
-        &settings,
-        &mut config.idle_timeout,
-        "sawtooth.consensus.pbft.idle_timeout",
+        &mut config.faulty_primary_timeout,
+        "sawtooth.consensus.pbft.faulty_primary_timeout",
     );
 
-    // Check to make sure block_duration < commit_timeout
-    if config.block_duration >= config.commit_timeout {
+    // Check to make sure block_duration < faulty_primary_timeout
+    if config.block_duration >= config.faulty_primary_timeout {
         panic!("Block duration must be less than the view change timeout");
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -132,7 +132,7 @@ fn handle_update(
             warn!("{}: BlockInvalid received, starting view change", state);
             node.propose_view_change(state)?
         }
-        Ok(Update::BlockCommit(block_id)) => node.on_block_commit(block_id, state)?,
+        Ok(Update::BlockCommit(block_id)) => node.on_block_commit(block_id, state),
         Ok(Update::PeerMessage(message, sender_id)) => {
             let parsed_message = ParsedMessage::from_peer_message(message, false)?;
             let signer_id = parsed_message.info().get_signer_id().to_vec();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -70,7 +70,7 @@ impl Engine for PbftEngine {
 
         debug!("Starting state: {:#?}", **pbft_state.read());
 
-        node.start_idle_timeout(&mut pbft_state.write());
+        node.start_faulty_primary_timeout(&mut pbft_state.write());
 
         // Event loop. Keep going until we receive a shutdown message.
         loop {
@@ -91,14 +91,10 @@ impl Engine for PbftEngine {
                     error!("{}", e);
                 }
 
-                // Every so often, check to see if commit timeout has expired; initiate ViewChange
-                // if necessary
-                if node.check_commit_timeout_expired(state) {
-                    handle_pbft_result(node.propose_view_change(state));
-                }
-                // Every so often, check to see if idle timeout has expired; initiate ViewChange if
-                // necessary
-                if node.check_idle_timeout_expired(state) {
+                // Every so often, check to see if the faulty primary timeout has expired; initiate
+                // ViewChange if necessary
+                if node.check_faulty_primary_timeout_expired(state) {
+                    warn!("Faulty primary timeout expired; proposing view change");
                     handle_pbft_result(node.propose_view_change(state));
                 }
             });

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,9 @@ pub enum PbftError {
     /// Too many or too few messages recieved so far (expected, got)
     WrongNumMessages(PbftMessageType, usize, usize),
 
+    /// Too many or too few consenus seals found (expected, got)
+    WrongNumSeals(usize, usize),
+
     /// The block in the message doesn't match the one this node was expecting
     BlockMismatch(PbftBlock, PbftBlock),
 
@@ -75,6 +78,7 @@ impl Error for PbftError {
         match self {
             SerializationError(_) => "SerializationError",
             WrongNumMessages(_, _, _) => "WrongNumMessages",
+            WrongNumSeals(_, _) => "WrongNumSeals",
             BlockMismatch(_, _) => "BlockMismatch",
             MessageMismatch(_) => "MessageMismatch",
             ViewMismatch(_, _) => "ViewMismatch",
@@ -99,6 +103,11 @@ impl fmt::Display for PbftError {
                 f,
                 "Wrong number of {:?} messages in this sequence (expected {}, got {})",
                 t, exp, got
+            ),
+            PbftError::WrongNumSeals(exp, got) => write!(
+                f,
+                "Wrong number of consensus seals found (expected {}, got {})",
+                exp, got
             ),
             PbftError::MessageMismatch(t) => write!(f, "{:?} message mismatch", t),
             PbftError::ViewMismatch(exp, got) => write!(f, "View mismatch: {} != {}", exp, got),

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,9 @@ pub enum PbftError {
 
     /// The message should only come from the primary, but was sent by a secondary node
     NotFromPrimary,
+
+    /// Got a PrePrepare without a matching BlockNew
+    NoBlockNew,
 }
 
 impl Error for PbftError {
@@ -87,6 +90,7 @@ impl Error for PbftError {
             NoWorkingBlock => "NoWorkingBlock",
             NotReadyForMessage => "NotReadyForMessage",
             NotFromPrimary => "NotFromPrimary",
+            NoBlockNew => "NoBlockNew",
         }
     }
 }
@@ -124,6 +128,7 @@ impl fmt::Display for PbftError {
                 f,
                 "Message should be from primary, but was sent by secondary"
             ),
+            PbftError::NoBlockNew => write!(f, "Got a PrePrepare without a matching BlockNew"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,10 +44,6 @@ pub enum PbftError {
     /// The message is in a different view than this node is
     ViewMismatch(usize, usize),
 
-    /// The message has a sequence number that is not between watermarks
-    /// (message's sequence number, low watermark, high watermark)
-    InvalidSequenceNumber(usize, usize, usize),
-
     /// Internal PBFT error (description)
     InternalError(String),
 
@@ -82,7 +78,6 @@ impl Error for PbftError {
             BlockMismatch(_, _) => "BlockMismatch",
             MessageMismatch(_) => "MessageMismatch",
             ViewMismatch(_, _) => "ViewMismatch",
-            InvalidSequenceNumber(_, _, _) => "InvalidSequenceNumber",
             InternalError(_) => "InternalError",
             NodeNotFound => "NodeNotFound",
             WrongNumBlocks => "WrongNumBlocks",
@@ -107,11 +102,6 @@ impl fmt::Display for PbftError {
             ),
             PbftError::MessageMismatch(t) => write!(f, "{:?} message mismatch", t),
             PbftError::ViewMismatch(exp, got) => write!(f, "View mismatch: {} != {}", exp, got),
-            PbftError::InvalidSequenceNumber(got, low, high) => write!(
-                f,
-                "Invalid sequence number: {} is not in range [{},{})",
-                got, low, high
-            ),
             PbftError::BlockMismatch(exp, got) => write!(
                 f,
                 "{:?} != {:?}",

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -41,7 +41,7 @@ use crate::state::{PbftPhase, PbftState};
 /// - The message's view matches the node's current view (handled by message log)
 /// - The sequence number is between the low and high watermarks (handled by message log)
 ///
-/// If a `PrePrepare` message is accepted, we update the phase and working block
+/// If a `PrePrepare` message is accepted, we update the phase
 pub fn pre_prepare(
     state: &mut PbftState,
     msg_log: &mut PbftLog,
@@ -85,7 +85,6 @@ pub fn pre_prepare(
     // We only switch to Preparing if this is the PrePrepare for the current sequence number
     if message.info().get_seq_num() == state.seq_num {
         state.switch_phase(PbftPhase::Preparing);
-        state.working_block = Some(message.get_block().clone());
     }
 
     Ok(())

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -152,8 +152,6 @@ pub fn force_view_change(state: &mut PbftState, service: &mut Service) {
     } else {
         become_secondary(state)
     }
-
-    state.discard_current_block();
 }
 
 fn check_received_enough_view_changes(

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -41,7 +41,7 @@ use crate::state::{PbftPhase, PbftState};
 /// - The message's view matches the node's current view (handled by message log)
 /// - The sequence number is between the low and high watermarks (handled by message log)
 ///
-/// If a `PrePrepare` message is accepted, we update the phase
+/// If a `PrePrepare` message is accepted, we update the phase and stop the view change timer
 pub fn pre_prepare(
     state: &mut PbftState,
     msg_log: &mut PbftLog,
@@ -82,9 +82,11 @@ pub fn pre_prepare(
 
     msg_log.add_message(message.clone(), state)?;
 
-    // We only switch to Preparing if this is the PrePrepare for the current sequence number
+    // We only switch to Preparing and stop the faulty primary timeout if this is the PrePrepare
+    // for the current sequence number
     if message.info().get_seq_num() == state.seq_num {
         state.switch_phase(PbftPhase::Preparing);
+        state.faulty_primary_timeout.stop();
     }
 
     Ok(())

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -27,9 +27,12 @@ use std::hash::{Hash, Hasher};
 use hex;
 
 use crate::message_type::PbftMessageType;
-use crate::protos::pbft_message::{PbftBlock, PbftMessage, PbftMessageInfo, PbftViewChange};
+use crate::protos::pbft_message::{
+    PbftBlock, PbftMessage, PbftMessageInfo, PbftSeal, PbftSignedCommitVote, PbftViewChange,
+};
 
 impl Eq for PbftMessage {}
+impl Eq for PbftSeal {}
 impl Eq for PbftViewChange {}
 
 impl Hash for PbftMessageInfo {
@@ -57,13 +60,28 @@ impl Hash for PbftMessage {
     }
 }
 
+impl Hash for PbftSeal {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.get_previous_id().hash(state);
+        self.get_summary().hash(state);
+        for vote in self.get_previous_commit_votes() {
+            vote.hash(state);
+        }
+    }
+}
+
+impl Hash for PbftSignedCommitVote {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.get_header_bytes().hash(state);
+        self.get_header_signature().hash(state);
+        self.get_message_bytes().hash(state);
+    }
+}
+
 impl Hash for PbftViewChange {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.get_info().hash(state);
-        for msg in self.get_checkpoint_messages().iter() {
-            msg.get_info().hash(state);
-            msg.get_block().hash(state);
-        }
+        self.get_seal().hash(state);
     }
 }
 

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -28,7 +28,7 @@ use sawtooth_sdk::consensus::engine::Block;
 
 use crate::config::PbftConfig;
 use crate::error::PbftError;
-use crate::message_type::{ParsedMessage, PbftHint, PbftMessageType};
+use crate::message_type::{ParsedMessage, PbftMessageType};
 use crate::protos::pbft_message::{PbftMessage, PbftMessageInfo};
 use crate::state::PbftState;
 
@@ -250,32 +250,6 @@ impl PbftLog {
         trace!("{}", self);
 
         Ok(())
-    }
-
-    /// Adds a message the (back)log, based on the given `PbftHint`
-    ///
-    /// Past messages are added to the general message log
-    /// Future messages are added to the backlog of messages to handle at a later time
-    /// Present messages are ignored, as they're generally added immediately after
-    /// this method is called by the calling code, except for `PrePrepare` messages
-    #[allow(clippy::ptr_arg)]
-    pub fn add_message_with_hint(
-        &mut self,
-        msg: ParsedMessage,
-        hint: &PbftHint,
-        state: &PbftState,
-    ) -> Result<(), PbftError> {
-        match hint {
-            PbftHint::FutureMessage => {
-                self.push_backlog(msg);
-                Err(PbftError::NotReadyForMessage)
-            }
-            PbftHint::PastMessage => {
-                self.add_message(msg, state)?;
-                Err(PbftError::NotReadyForMessage)
-            }
-            PbftHint::PresentMessage => Ok(()),
-        }
     }
 
     /// Obtain all messages from the log that match a given type and sequence_number

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -24,7 +24,6 @@ use std::fmt;
 
 use hex;
 use itertools::Itertools;
-use sawtooth_sdk::consensus::engine::Block;
 
 use crate::config::PbftConfig;
 use crate::error::PbftError;
@@ -60,9 +59,6 @@ pub struct PbftLog {
 
     /// Backlog of messages (from peers) with sender's ID
     backlog: VecDeque<ParsedMessage>,
-
-    /// Backlog of blocks (from BlockNews messages)
-    block_backlog: VecDeque<Block>,
 
     /// The most recent checkpoint that contains proof
     pub latest_stable_checkpoint: Option<PbftStableCheckpoint>,
@@ -108,7 +104,6 @@ impl PbftLog {
             high_water_mark: config.max_log_size,
             max_log_size: config.max_log_size,
             backlog: VecDeque::new(),
-            block_backlog: VecDeque::new(),
             latest_stable_checkpoint: None,
         }
     }
@@ -362,14 +357,6 @@ impl PbftLog {
 
     pub fn pop_backlog(&mut self) -> Option<ParsedMessage> {
         self.backlog.pop_front()
-    }
-
-    pub fn push_block_backlog(&mut self, msg: Block) {
-        self.block_backlog.push_back(msg);
-    }
-
-    pub fn pop_block_backlog(&mut self) -> Option<Block> {
-        self.block_backlog.pop_front()
     }
 }
 

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -224,7 +224,6 @@ pub enum PbftMessageType {
 
     /// Auxiliary PBFT messages
     BlockNew,
-    Checkpoint,
     ViewChange,
 
     Unset,
@@ -237,7 +236,6 @@ impl fmt::Display for PbftMessageType {
             PbftMessageType::Prepare => "Pr",
             PbftMessageType::Commit => "Co",
             PbftMessageType::BlockNew => "BN",
-            PbftMessageType::Checkpoint => "CP",
             PbftMessageType::ViewChange => "VC",
             PbftMessageType::Unset => "Un",
         };
@@ -265,7 +263,6 @@ impl<'a> From<&'a str> for PbftMessageType {
             "Commit" => PbftMessageType::Commit,
             "BlockNew" => PbftMessageType::BlockNew,
             "ViewChange" => PbftMessageType::ViewChange,
-            "Checkpoint" => PbftMessageType::Checkpoint,
             _ => {
                 warn!("Unhandled PBFT message type: {}", s);
                 PbftMessageType::Unset

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -214,19 +214,6 @@ impl ParsedMessage {
     }
 }
 
-/// Enum for showing the difference between future messages, present messages, and past messages.
-#[derive(Debug, PartialEq)]
-pub enum PbftHint {
-    /// A future message. The node is not ready to process it yet.
-    FutureMessage,
-
-    /// A past message. It's possible the node may still need it though, so it is added to the log.
-    PastMessage,
-
-    /// A present message. The node is ready to process this message immediately.
-    PresentMessage,
-}
-
 // Messages related to PBFT consensus
 #[derive(Debug, PartialEq, PartialOrd)]
 pub enum PbftMessageType {

--- a/src/node.rs
+++ b/src/node.rs
@@ -241,10 +241,13 @@ impl PbftNode {
 
     #[allow(clippy::ptr_arg)]
     fn check_if_checkpoint_started(&mut self, msg: &ParsedMessage, state: &mut PbftState) -> bool {
-        // Not ready to receive checkpoint yet; only acceptable in NotStarted
-        if state.phase != PbftPhase::NotStarted {
+        // Not ready to receive checkpoint yet; only acceptable in PrePreparing
+        if state.phase != PbftPhase::PrePreparing {
             self.msg_log.push_backlog(msg.clone());
-            debug!("{}: Not in NotStarted; not handling checkpoint yet", state);
+            debug!(
+                "{}: Not in PrePreparing; not handling checkpoint yet",
+                state
+            );
             false
         } else {
             true
@@ -658,23 +661,14 @@ impl PbftNode {
             return Ok(());
         }
 
-        if block.block_num > head.block_num + 1
-            || state.switch_phase(PbftPhase::PrePreparing).is_none()
-        {
-            debug!(
-                "{}: Not ready for block {}, pushing to backlog",
-                state,
-                &hex::encode(block.block_id.clone())[..6]
-            );
-            self.msg_log.push_block_backlog(block.clone());
-            return Ok(());
-        }
-
         self.msg_log
             .add_message(ParsedMessage::from_pbft_message(msg), state)?;
-        state.working_block = WorkingBlockOption::TentativeWorkingBlock(block.block_id);
-        state.idle_timeout.stop();
-        state.commit_timeout.start();
+
+        if block.block_num == head.block_num + 1 {
+            state.working_block = WorkingBlockOption::TentativeWorkingBlock(block.block_id);
+            state.idle_timeout.stop();
+            state.commit_timeout.start();
+        }
 
         if state.is_primary() {
             let s = state.seq_num;
@@ -686,9 +680,9 @@ impl PbftNode {
     /// Handle a `BlockCommit` update from the Validator
     /// Since the block was successfully committed, the primary is not faulty and the view change
     /// timer can be stopped. If this node is a primary, then initialize a new block. Both node
-    /// roles transition back to the `NotStarted` phase. If this node is at a checkpoint after the
-    /// previously committed block (`checkpoint_period` blocks have been committed since the last
-    /// checkpoint), then start a checkpoint.
+    /// roles transition back to the `PrePreparing` phase. If this node is at a checkpoint after
+    /// the previously committed block (`checkpoint_period` blocks have been committed since the
+    /// last checkpoint), then start a checkpoint.
     pub fn on_block_commit(
         &mut self,
         block_id: BlockId,
@@ -707,7 +701,7 @@ impl PbftNode {
                     .unwrap_or_else(|err| error!("Couldn't initialize block: {}", err));
             }
 
-            state.switch_phase(PbftPhase::NotStarted);
+            state.switch_phase(PbftPhase::PrePreparing);
             state.seq_num += 1;
 
             // Start a view change if we need to force one for fairness or if membership changed
@@ -715,7 +709,7 @@ impl PbftNode {
                 self.force_view_change(state);
             }
 
-            // Start a checkpoint in NotStarted, if we're at one
+            // Start a checkpoint in PrePreparing, if we're at one
             if self.msg_log.at_checkpoint() {
                 self.start_checkpoint(state)?;
             }
@@ -822,7 +816,7 @@ impl PbftNode {
         // Only the primary takes care of this, and we try publishing a block
         // on every engine loop, even if it's not yet ready. This isn't an error,
         // so just return Ok(()).
-        if !state.is_primary() || state.phase != PbftPhase::NotStarted {
+        if !state.is_primary() || state.phase != PbftPhase::PrePreparing {
             return Ok(());
         }
 
@@ -906,12 +900,6 @@ impl PbftNode {
         if let Some(msg) = self.msg_log.pop_backlog() {
             debug!("{}: Popping message from backlog", state);
             peer_res = self.on_peer_message(msg, state);
-        }
-        if state.mode == PbftMode::Normal && state.phase == PbftPhase::NotStarted {
-            if let Some(msg) = self.msg_log.pop_block_backlog() {
-                debug!("{}: Popping BlockNew from backlog", state);
-                self.on_block_new(msg, state)?;
-            }
         }
         peer_res
     }
@@ -1342,7 +1330,7 @@ mod tests {
 
         assert_eq!(state.id, vec![0]);
         assert_eq!(state.view, 0);
-        assert_eq!(state.phase, PbftPhase::NotStarted);
+        assert_eq!(state.phase, PbftPhase::PrePreparing);
         assert_eq!(state.mode, PbftMode::Normal);
         assert_eq!(state.pre_checkpoint_mode, PbftMode::Normal);
         assert_eq!(state.peer_ids, (0..4).map(|i| vec![i]).collect::<Vec<_>>());
@@ -1457,7 +1445,7 @@ mod tests {
 
         node.on_block_new(block, &mut state).unwrap();
 
-        assert_eq!(state.phase, PbftPhase::NotStarted);
+        assert_eq!(state.phase, PbftPhase::PrePreparing);
         assert_eq!(state.working_block, WorkingBlockOption::NoWorkingBlock);
     }
 
@@ -1485,7 +1473,7 @@ mod tests {
         assert_eq!(state0.seq_num, 1);
         node.on_block_commit(mock_block_id(1), &mut state0)
             .unwrap_or_else(handle_pbft_err);
-        assert_eq!(state0.phase, PbftPhase::NotStarted);
+        assert_eq!(state0.phase, PbftPhase::PrePreparing);
         assert_eq!(state0.seq_num, 2);
     }
 
@@ -1541,7 +1529,7 @@ mod tests {
 
         // Spoof the `commit_blocks()` call
         assert!(node1.on_block_commit(mock_block_id(1), &mut state1).is_ok());
-        assert_eq!(state1.phase, PbftPhase::NotStarted);
+        assert_eq!(state1.phase, PbftPhase::PrePreparing);
 
         // Make sure the block was actually committed
         let mut f = File::open(BLOCK_FILE).unwrap();
@@ -1663,7 +1651,7 @@ mod tests {
                 .unwrap();
         }
 
-        state0.phase = PbftPhase::NotStarted;
+        state0.phase = PbftPhase::PrePreparing;
         state0.working_block = WorkingBlockOption::WorkingBlock(pbft_block0.clone());
 
         node0.try_publish(&mut state0).unwrap();

--- a/src/state.rs
+++ b/src/state.rs
@@ -119,13 +119,9 @@ pub struct PbftState {
     /// The maximum number of faulty nodes in the network
     pub f: u64,
 
-    /// Timer used to make sure the primary is executing BlockCommits in a timely manner. If not,
-    /// then this node will initiate a view change.
-    pub commit_timeout: Timeout,
-
-    /// Timer used to force view changes if too much idle time has elapsed between the last block
-    /// being committed and the next block being proposed.
-    pub idle_timeout: Timeout,
+    /// Timer used to make sure the primary publishes blocks in a timely manner. If not, then this
+    /// node will initiate a view change.
+    pub faulty_primary_timeout: Timeout,
 
     pub forced_view_change_period: u64,
 
@@ -159,8 +155,7 @@ impl PbftState {
             mode: PbftMode::Normal,
             f,
             peer_ids: config.peers.clone(),
-            commit_timeout: Timeout::new(config.commit_timeout),
-            idle_timeout: Timeout::new(config.idle_timeout),
+            faulty_primary_timeout: Timeout::new(config.faulty_primary_timeout),
             forced_view_change_period: config.forced_view_change_period,
             working_block: None,
         }
@@ -236,8 +231,7 @@ impl PbftState {
         self.working_block = None;
         self.phase = PbftPhase::PrePreparing;
         self.mode = PbftMode::Normal;
-        self.commit_timeout.stop();
-        self.idle_timeout.start();
+        self.faulty_primary_timeout.start();
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -50,7 +50,6 @@ pub enum PbftPhase {
 pub enum PbftMode {
     Normal,
     ViewChanging,
-    Checkpointing,
 }
 
 impl fmt::Display for PbftState {
@@ -58,7 +57,6 @@ impl fmt::Display for PbftState {
         let ast = if self.is_primary() { "*" } else { " " };
         let mode = match self.mode {
             PbftMode::Normal => "N",
-            PbftMode::Checkpointing => "C",
             PbftMode::ViewChanging => "V",
         };
 
@@ -135,9 +133,8 @@ pub struct PbftState {
     /// Is this node primary or secondary?
     role: PbftNodeRole,
 
-    /// Normal operation, view change, or checkpointing. Previous mode is stored when checkpointing
+    /// Normal operation or view changing
     pub mode: PbftMode,
-    pub pre_checkpoint_mode: PbftMode,
 
     /// Map of peers in the network, including ourselves
     pub peer_ids: Vec<PeerId>,
@@ -183,7 +180,6 @@ impl PbftState {
                 PbftNodeRole::Secondary
             },
             mode: PbftMode::Normal,
-            pre_checkpoint_mode: PbftMode::Normal,
             f,
             peer_ids: config.peers.clone(),
             commit_timeout: Timeout::new(config.commit_timeout),

--- a/tests/client.yaml
+++ b/tests/client.yaml
@@ -45,7 +45,6 @@ services:
           sawtooth.consensus.algorithm.version=0.1 \
           sawtooth.consensus.pbft.peers=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
           sawtooth.consensus.pbft.block_duration=100 \
-          sawtooth.consensus.pbft.checkpoint_period=10 \
           sawtooth.consensus.pbft.view_change_timeout=4000 \
           sawtooth.consensus.pbft.message_timeout=10 \
           sawtooth.consensus.pbft.max_log_size=1000 \

--- a/tests/grafana.yaml
+++ b/tests/grafana.yaml
@@ -71,7 +71,6 @@ services:
           sawtooth.consensus.algorithm.version=0.1 \
           sawtooth.consensus.pbft.peers=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
           sawtooth.consensus.pbft.block_duration=100 \
-          sawtooth.consensus.pbft.checkpoint_period=10 \
           sawtooth.consensus.pbft.view_change_timeout=4000 \
           sawtooth.consensus.pbft.message_timeout=10 \
           sawtooth.consensus.pbft.max_log_size=1000 \

--- a/tests/test_liveness.yaml
+++ b/tests/test_liveness.yaml
@@ -74,7 +74,6 @@ services:
           sawtooth.consensus.algorithm.version=0.1.0 \
           sawtooth.consensus.pbft.peers=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
           sawtooth.consensus.pbft.block_duration=100 \
-          sawtooth.consensus.pbft.checkpoint_period=10 \
           sawtooth.consensus.pbft.view_change_timeout=4000 \
           sawtooth.consensus.pbft.message_timeout=10 \
           sawtooth.consensus.pbft.max_log_size=1000 \


### PR DESCRIPTION
Replace the `idle_timeout` and the `commit_timeout` with a single
`view_change_timeout`; this is a departure from the PBFT definition and
the view change RFC
(https://github.com/hyperledger/sawtooth-rfcs/pull/29/files).

The new timeout is roughly equivalent to the `idle_timeout`, but with
the key difference that it is stopped when a node has both a BlockNew
and a corresponding PrePrepare for the next block rather than just a
BlockNew.

This timeout will guarantee liveness in the presence of a faulty primary
by ensuring that the primary cannot indefinitely halt the network by
failing to produce a block or a PrePrepare. However, we do not need to
use a full commit timeout to ensure that a block is actually committed
on time, because whether or not a block is committed does not depend on
the primary. Once the primary has produced a block and a PrePrepare, the
network as a whole is responsible for validating the block and sending
the required messages to actually commit it; a faulty primary cannot
prevent this on its own. This means that if there is a failure to commit
a block, then there are more than f faulty nodes, and therefore a view
change will not be able to provide liveness.

This change provides the same liveness guarantees as before, but
prevents the network from unnecessarily starting a view change when it
will not help the network continue progress.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

Based on #67