### PR TITLE
Update block management

### DIFF
--- a/protos/pbft_message.proto
+++ b/protos/pbft_message.proto
@@ -15,20 +15,6 @@
 
 syntax = "proto3";
 
-// PBFT-specific block information (don't need to keep sending the whole payload
-// around the network)
-message PbftBlock {
-  bytes block_id = 1;
-
-  bytes signer_id = 2;
-
-  uint64 block_num = 3;
-
-  bytes summary = 4;
-
-  bytes seal = 5;
-}
-
 // Represents all common information used in a PBFT message
 message PbftMessageInfo {
   // Type of the message
@@ -50,8 +36,8 @@ message PbftMessage {
   // Message information
   PbftMessageInfo info = 1;
 
-  // The actual message
-  PbftBlock block = 2;
+  // The block this message is for
+  bytes block_id = 2;
 }
 
 // A message sent by the new primary to signify that the new view should be

--- a/protos/pbft_message.proto
+++ b/protos/pbft_message.proto
@@ -25,6 +25,8 @@ message PbftBlock {
   uint64 block_num = 3;
 
   bytes summary = 4;
+
+  bytes seal = 5;
 }
 
 // Represents all common information used in a PBFT message

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,6 @@
 use std::error::Error;
 use std::fmt;
 
-use hex;
 use protobuf::error::ProtobufError;
 use sawtooth_sdk::consensus::engine::Error as ServError;
 

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -25,11 +25,11 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 
 use hex;
-use sawtooth_sdk::consensus::engine::{Block, PeerId};
+use sawtooth_sdk::consensus::engine::PeerId;
 
 use crate::message_type::PbftMessageType;
 use crate::protos::pbft_message::{
-    PbftBlock, PbftMessage, PbftMessageInfo, PbftNewView, PbftSeal, PbftSignedVote,
+    PbftMessage, PbftMessageInfo, PbftNewView, PbftSeal, PbftSignedVote,
 };
 
 impl Eq for PbftMessage {}
@@ -45,19 +45,10 @@ impl Hash for PbftMessageInfo {
     }
 }
 
-impl Hash for PbftBlock {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.get_block_id().hash(state);
-        self.get_block_num().hash(state);
-        self.get_summary().hash(state);
-        self.get_signer_id().hash(state);
-    }
-}
-
 impl Hash for PbftMessage {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.get_info().hash(state);
-        self.get_block().hash(state);
+        self.get_block_id().hash(state);
     }
 }
 
@@ -96,18 +87,6 @@ impl fmt::Display for PbftMessageInfo {
             self.get_view(),
             &hex::encode(self.get_signer_id())[..6],
         )
-    }
-}
-
-impl From<Block> for PbftBlock {
-    fn from(block: Block) -> Self {
-        let mut pbft_block = PbftBlock::new();
-        pbft_block.set_block_id(block.block_id);
-        pbft_block.set_signer_id(block.signer_id);
-        pbft_block.set_block_num(block.block_num);
-        pbft_block.set_summary(block.summary);
-        pbft_block.set_seal(block.payload);
-        pbft_block
     }
 }
 

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -106,6 +106,7 @@ impl From<Block> for PbftBlock {
         pbft_block.set_signer_id(block.signer_id);
         pbft_block.set_block_num(block.block_num);
         pbft_block.set_summary(block.summary);
+        pbft_block.set_seal(block.payload);
         pbft_block
     }
 }

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -23,6 +23,7 @@ use std::collections::{HashSet, VecDeque};
 use std::fmt;
 
 use hex;
+use sawtooth_sdk::consensus::engine::Block;
 
 use crate::config::PbftConfig;
 use crate::error::PbftError;
@@ -32,6 +33,9 @@ use crate::state::PbftState;
 
 /// Struct for storing messages that a PbftNode receives
 pub struct PbftLog {
+    /// All blocks received from the validator that have not been garbage collected
+    blocks: HashSet<Block>,
+
     /// All messages accepted by the node that have not been garbage collected
     messages: HashSet<ParsedMessage>,
 
@@ -70,10 +74,32 @@ impl PbftLog {
     /// Create a new, empty `PbftLog` with the `max_log_size` specified in the `config`
     pub fn new(config: &PbftConfig) -> Self {
         PbftLog {
+            blocks: HashSet::new(),
             messages: HashSet::new(),
             max_log_size: config.max_log_size,
             pre_prepare_backlog: VecDeque::new(),
         }
+    }
+
+    /// Add a `Block` to the log
+    pub fn add_block(&mut self, block: Block) {
+        trace!("Adding block to log: {:?}", block);
+        self.blocks.insert(block);
+    }
+
+    /// Get all `Block`s in the message log with the specified block number
+    pub fn get_blocks(&self, block_num: u64) -> Vec<&Block> {
+        self.blocks
+            .iter()
+            .filter(|block| block.block_num == block_num)
+            .collect()
+    }
+
+    /// Check if the log contains a block with the specified block ID
+    pub fn has_block(&self, block_id: &[u8]) -> bool {
+        self.blocks
+            .iter()
+            .any(|block| block.block_id.as_slice() == block_id)
     }
 
     /// Add a parsed PBFT message to the log
@@ -95,23 +121,15 @@ impl PbftLog {
         Ok(())
     }
 
-    /// Check if the log contains a BlockNew message with the specified block ID
-    pub fn has_block(&self, block_id: &[u8]) -> bool {
-        self.messages.iter().any(|msg| {
-            msg.info().get_msg_type() == String::from(PbftMessageType::BlockNew)
-                && msg.get_block().get_block_id() == block_id
-        })
-    }
-
     /// Check if the log contains `required` number of messages that match:
     /// - The `msg_type`
     /// - Sequence + view number of the provided `ref_msg`
-    /// - The block in `ref_msg` (only if `check_block` is `true`)
+    /// - The block_id in `ref_msg` (only if `check_block_id` is `true`)
     pub fn has_required_msgs(
         &self,
         msg_type: PbftMessageType,
         ref_msg: &ParsedMessage,
-        check_block: bool,
+        check_block_id: bool,
         required: u64,
     ) -> bool {
         let msgs = self.get_messages_of_type_seq_view(
@@ -120,9 +138,9 @@ impl PbftLog {
             ref_msg.info().get_view(),
         );
 
-        let msgs = if check_block {
+        let msgs = if check_block_id {
             msgs.iter()
-                .filter(|msg| msg.get_block() == ref_msg.get_block())
+                .filter(|msg| msg.get_block_id() == ref_msg.get_block_id())
                 .cloned()
                 .collect()
         } else {
@@ -202,6 +220,9 @@ impl PbftLog {
             // needs to build the next consensus seal
             self.messages
                 .retain(|msg| msg.info().get_seq_num() >= current_seq_num - 1);
+
+            self.blocks
+                .retain(|block| block.block_num >= current_seq_num);
         }
 
         // Clean out stale PrePrepares
@@ -224,8 +245,7 @@ impl PbftLog {
 mod tests {
     use super::*;
     use crate::config;
-    use crate::hash::hash_sha256;
-    use crate::protos::pbft_message::{PbftBlock, PbftMessage};
+    use crate::protos::pbft_message::PbftMessage;
     use sawtooth_sdk::consensus::engine::PeerId;
 
     /// Create a PbftMessage, given its type, view, sequence number, and who it's from
@@ -234,7 +254,6 @@ mod tests {
         view: u64,
         seq_num: u64,
         signer_id: PeerId,
-        block_signer_id: PeerId,
     ) -> ParsedMessage {
         let mut info = PbftMessageInfo::new();
         info.set_msg_type(String::from(msg_type));
@@ -242,16 +261,9 @@ mod tests {
         info.set_seq_num(seq_num);
         info.set_signer_id(Vec::<u8>::from(signer_id.clone()));
 
-        let mut pbft_block = PbftBlock::new();
-        pbft_block.set_block_id(hash_sha256(
-            format!("I'm a block with block num {}", seq_num).as_bytes(),
-        ));
-        pbft_block.set_signer_id(Vec::<u8>::from(block_signer_id));
-        pbft_block.set_block_num(seq_num);
-
         let mut msg = PbftMessage::new();
         msg.set_info(info);
-        msg.set_block(pbft_block);
+        msg.set_block_id(vec![]);
 
         ParsedMessage::from_pbft_message(msg)
     }
@@ -268,13 +280,7 @@ mod tests {
         let mut log = PbftLog::new(&cfg);
         let state = PbftState::new(vec![], 0, &cfg);
 
-        let msg = make_msg(
-            PbftMessageType::PrePrepare,
-            0,
-            1,
-            get_peer_id(&cfg, 0),
-            get_peer_id(&cfg, 0),
-        );
+        let msg = make_msg(PbftMessageType::PrePrepare, 0, 1, get_peer_id(&cfg, 0));
 
         log.add_message(msg.clone(), &state).unwrap();
 
@@ -293,44 +299,19 @@ mod tests {
         let state = PbftState::new(vec![], 0, &cfg);
 
         for seq in 1..5 {
-            let msg = make_msg(
-                PbftMessageType::BlockNew,
-                0,
-                seq,
-                get_peer_id(&cfg, 0),
-                get_peer_id(&cfg, 0),
-            );
-            log.add_message(msg.clone(), &state).unwrap();
+            log.add_block(Block::default());
 
-            let msg = make_msg(
-                PbftMessageType::PrePrepare,
-                0,
-                seq,
-                get_peer_id(&cfg, 0),
-                get_peer_id(&cfg, 0),
-            );
+            let msg = make_msg(PbftMessageType::PrePrepare, 0, seq, get_peer_id(&cfg, 0));
             log.add_message(msg.clone(), &state).unwrap();
 
             for peer in 0..4 {
-                let msg = make_msg(
-                    PbftMessageType::Prepare,
-                    0,
-                    seq,
-                    get_peer_id(&cfg, peer),
-                    get_peer_id(&cfg, 0),
-                );
+                let msg = make_msg(PbftMessageType::Prepare, 0, seq, get_peer_id(&cfg, peer));
 
                 log.add_message(msg.clone(), &state).unwrap();
             }
 
             for peer in 0..4 {
-                let msg = make_msg(
-                    PbftMessageType::Commit,
-                    0,
-                    seq,
-                    get_peer_id(&cfg, peer),
-                    get_peer_id(&cfg, 0),
-                );
+                let msg = make_msg(PbftMessageType::Commit, 0, seq, get_peer_id(&cfg, peer));
 
                 log.add_message(msg.clone(), &state).unwrap();
             }
@@ -341,7 +322,6 @@ mod tests {
 
         for old in 1..3 {
             for msg_type in &[
-                PbftMessageType::BlockNew,
                 PbftMessageType::PrePrepare,
                 PbftMessageType::Prepare,
                 PbftMessageType::Commit,
@@ -353,9 +333,13 @@ mod tests {
             }
         }
 
-        for msg_type in vec![PbftMessageType::BlockNew, PbftMessageType::PrePrepare] {
-            assert_eq!(log.get_messages_of_type_seq_view(msg_type, 4, 0).len(), 1);
-        }
+        assert!(log.blocks.is_empty());
+
+        assert_eq!(
+            log.get_messages_of_type_seq_view(PbftMessageType::PrePrepare, 4, 0)
+                .len(),
+            1
+        );
 
         for msg_type in vec![PbftMessageType::Prepare, PbftMessageType::Commit] {
             assert_eq!(log.get_messages_of_type_seq_view(msg_type, 4, 0).len(), 4);

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -95,6 +95,14 @@ impl PbftLog {
         Ok(())
     }
 
+    /// Check if the log contains a BlockNew message with the specified block ID
+    pub fn has_block(&self, block_id: &[u8]) -> bool {
+        self.messages.iter().any(|msg| {
+            msg.info().get_msg_type() == String::from(PbftMessageType::BlockNew)
+                && msg.get_block().get_block_id() == block_id
+        })
+    }
+
     /// Check if the log contains `required` number of messages that match:
     /// - The `msg_type`
     /// - Sequence + view number of the provided `ref_msg`

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -99,7 +99,7 @@ impl PbftLog {
     /// - The `msg_type`
     /// - Sequence + view number of the provided `ref_msg`
     /// - The block in `ref_msg` (only if `check_block` is `true`)
-    pub fn log_has_required_msgs(
+    pub fn has_required_msgs(
         &self,
         msg_type: PbftMessageType,
         ref_msg: &ParsedMessage,

--- a/src/node.rs
+++ b/src/node.rs
@@ -444,8 +444,8 @@ impl PbftNode {
 
         info!("{}: Updated to view {}", state, state.view);
 
-        // Initialize a new block if necessary
-        if state.is_primary() && state.working_block.is_none() {
+        // Initialize a new block if this node is the new primary
+        if state.is_primary() {
             self.service.initialize_block(None).map_err(|err| {
                 PbftError::ServiceError("Couldn't initialize block after view change".into(), err)
             })?;

--- a/src/node.rs
+++ b/src/node.rs
@@ -516,7 +516,7 @@ impl PbftNode {
         if block.block_num > state.seq_num
             && state.phase != PbftPhase::Finishing(block.previous_id.clone())
         {
-            self.catchup(state, &block)?;
+            self.catchup(state, &pbft_block)?;
         } else if block.block_num == state.seq_num {
             // This is the block we're waiting for, so we update state
             state.working_block = Some(msg.get_block().clone());
@@ -535,14 +535,14 @@ impl PbftNode {
     }
 
     /// Use the given block's consensus seal to verify and commit the block this node is working on
-    fn catchup(&mut self, state: &mut PbftState, block: &Block) -> Result<(), PbftError> {
+    fn catchup(&mut self, state: &mut PbftState, block: &PbftBlock) -> Result<(), PbftError> {
         info!(
             "{}: Attempting to commit block {} using catch-up",
             state, state.seq_num
         );
 
         // Parse messages from the seal
-        let seal: PbftSeal = protobuf::parse_from_bytes(&block.payload).map_err(|err| {
+        let seal: PbftSeal = protobuf::parse_from_bytes(block.get_seal()).map_err(|err| {
             PbftError::SerializationError("Error parsing seal for catch-up".into(), err)
         })?;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -458,8 +458,8 @@ impl PbftNode {
     ///
     /// The validator has received a new block; verify the block's consensus seal and add the
     /// BlockNew to the message log. If this is the block we are waiting for: set it as the working
-    /// block, update the idle & commit timers, and broadcast a PrePrepare if this node is the
-    /// primary. If this is the block after the one this node is working on, use it to catch up.
+    /// block and broadcast a PrePrepare if this node is the primary. If this is the block after
+    /// the one this node is working on, use it to catch up.
     pub fn on_block_new(&mut self, block: Block, state: &mut PbftState) -> Result<(), PbftError> {
         info!("{}: Got BlockNew: {}", state, block.block_num);
         debug!("Block details: {:?}", block);
@@ -603,8 +603,8 @@ impl PbftNode {
     /// Handle a `BlockCommit` update from the Validator
     ///
     /// A block was sucessfully committed; update state to be ready for the next block, make any
-    /// necessary view and membership changes, garbage collect the logs, update the commit & idle
-    /// timers, and start a new block if this node is the primary.
+    /// necessary view and membership changes, garbage collect the logs, and start a new block if
+    /// this node is the primary.
     pub fn on_block_commit(
         &mut self,
         block_id: BlockId,

--- a/src/node.rs
+++ b/src/node.rs
@@ -121,7 +121,7 @@ impl PbftNode {
     /// - The message's view matches the node's current view (handled by message log)
     ///
     /// Once a `PrePrepare` for the current sequence number is accepted and added to the log, the
-    /// node node will instruct the validator to validate the block
+    /// node node will switch to the Preparing phase and broadcast a `Prepare` message
     fn handle_pre_prepare(
         &mut self,
         msg: ParsedMessage,
@@ -436,8 +436,8 @@ impl PbftNode {
     /// Handle a `BlockNew` update from the Validator
     ///
     /// The validator has received a new block; verify the block's consensus seal and add the block
-    /// to the log. If this is the block we are waiting for and this node is the primary, broadcast
-    /// a PrePrepare. If this is a future block, use it to catch up.
+    /// to the log. If this is the block the node is waiting for and this node is the primary,
+    /// broadcast a PrePrepare. If this is a future block, use it to catch up.
     pub fn on_block_new(&mut self, block: Block, state: &mut PbftState) -> Result<(), PbftError> {
         info!("{}: Got BlockNew: {}", state, block.block_num);
         debug!("Block details: {:?}", block);

--- a/src/node.rs
+++ b/src/node.rs
@@ -235,7 +235,7 @@ impl PbftNode {
                 .msg_log
                 .get_first_msg(&info, PbftMessageType::PrePrepare)
             {
-                if self.msg_log.log_has_required_msgs(
+                if self.msg_log.has_required_msgs(
                     PbftMessageType::Prepare,
                     &pre_prep,
                     true,
@@ -279,7 +279,7 @@ impl PbftNode {
                 .msg_log
                 .get_first_msg(&info, PbftMessageType::PrePrepare)
             {
-                if self.msg_log.log_has_required_msgs(
+                if self.msg_log.has_required_msgs(
                     PbftMessageType::Commit,
                     &pre_prep,
                     true,
@@ -338,7 +338,7 @@ impl PbftNode {
         if match state.mode {
             PbftMode::ViewChanging(v) => msg_view > v,
             PbftMode::Normal => true,
-        } && self.msg_log.log_has_required_msgs(
+        } && self.msg_log.has_required_msgs(
             PbftMessageType::ViewChange,
             msg,
             false,
@@ -1600,7 +1600,7 @@ mod tests {
             .unwrap_or_else(panic_with_err);
 
         // Verify it worked
-        assert!(node0.msg_log.log_has_required_msgs(
+        assert!(node0.msg_log.has_required_msgs(
             PbftMessageType::PrePrepare,
             &valid_msg,
             true,

--- a/src/state.rs
+++ b/src/state.rs
@@ -25,7 +25,6 @@ use sawtooth_sdk::consensus::engine::{BlockId, PeerId};
 
 use crate::config::PbftConfig;
 use crate::error::PbftError;
-use crate::protos::pbft_message::PbftBlock;
 use crate::timing::Timeout;
 
 /// Phases of the PBFT algorithm, in `Normal` mode
@@ -61,23 +60,13 @@ impl fmt::Display for PbftState {
             PbftPhase::Finishing(ref id, cu) => format!("Fi {:?}/{}", &hex::encode(id)[..6], cu),
         };
 
-        let wb = match self.working_block {
-            Some(ref block) => format!(
-                "{}/{}",
-                block.block_num,
-                &hex::encode(block.get_block_id())[..6]
-            ),
-            None => String::from("~none~"),
-        };
-
         write!(
             f,
-            "({} {} {}, seq {}, wb {}), Node {}{}",
+            "({} {} {}, seq {}), Node {}{}",
             phase,
             mode,
             self.view,
             self.seq_num,
-            wb,
             ast,
             &hex::encode(self.id.clone())[..6],
         )
@@ -123,9 +112,6 @@ pub struct PbftState {
 
     /// How many blocks to commit before forcing a view change for fairness
     pub forced_view_change_period: u64,
-
-    /// The current block this node is working on
-    pub working_block: Option<PbftBlock>,
 }
 
 impl PbftState {
@@ -153,7 +139,6 @@ impl PbftState {
             view_change_timeout: Timeout::new(config.view_change_duration),
             view_change_duration: config.view_change_duration,
             forced_view_change_period: config.forced_view_change_period,
-            working_block: None,
         }
     }
 


### PR DESCRIPTION
Improvements to PBFT's block management, including:
- Bug fixes for the catch-up procedure
- Update to make primary always initialize a new block and not try to re-use old ones
- Removal of `state.working_block`
- Updates to uphold contract with the validator that the engine will make a decision on all blocks that are sent to it