### PR TITLE
Remove sphinxcontrib.openapi from doc build

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -50,7 +50,6 @@ RUN apt-get update && apt-get install -y -q \
     && pip3 install \
     sphinx \
     sphinxcontrib-httpdomain \
-    sphinxcontrib-openapi \
     sphinx_rtd_theme
 
 RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,6 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.imgmath',
     'sphinxcontrib.httpdomain',
-    'sphinxcontrib.openapi',
 ]
 
 # Autodoc settings


### PR DESCRIPTION
The PBFT docs do not need "sphinxcontrib.openapi" (it's for generating the Sawtooth REST API docs).

Signed-off-by: Anne Chenette <chenette@bitwise.io>