### PR TITLE
Implement final block catchup

### DIFF
--- a/protos/pbft_message.proto
+++ b/protos/pbft_message.proto
@@ -51,6 +51,15 @@ message PbftNewView {
   repeated PbftSignedVote view_changes = 2;
 }
 
+// A message sent to a node that has requested a seal for finishing catch-up
+message PbftSealResponse {
+  // Message information
+  PbftMessageInfo info = 1;
+
+  // The requested seal
+  PbftSeal seal = 2;
+}
+
 message PbftSignedVote {
   // Serialized ConsensusPeerMessage header
   bytes header_bytes = 1;

--- a/protos/pbft_message.proto
+++ b/protos/pbft_message.proto
@@ -63,13 +63,10 @@ message PbftSignedVote {
 }
 
 message PbftSeal {
-  // ID of the previous block
-  bytes previous_id = 1;
+  // ID of the block this seal verifies
+  bytes block_id = 1;
 
-  // Summary of the current block
-  bytes summary = 2;
-
-  // A list of Commit votes to prove the previous block commit (must contain at
-  // least 2f votes)
-  repeated PbftSignedVote previous_commit_votes = 3;
+  // A list of Commit votes to prove the block commit (must contain at least 2f
+  // votes)
+  repeated PbftSignedVote commit_votes = 2;
 }

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -30,11 +30,12 @@ use sawtooth_sdk::messages::consensus::ConsensusPeerMessageHeader;
 
 use crate::message_type::PbftMessageType;
 use crate::protos::pbft_message::{
-    PbftMessage, PbftMessageInfo, PbftNewView, PbftSeal, PbftSignedVote,
+    PbftMessage, PbftMessageInfo, PbftNewView, PbftSeal, PbftSealResponse, PbftSignedVote,
 };
 
 impl Eq for PbftMessage {}
 impl Eq for PbftSeal {}
+impl Eq for PbftSealResponse {}
 impl Eq for PbftNewView {}
 
 impl Hash for PbftMessageInfo {
@@ -59,6 +60,13 @@ impl Hash for PbftSeal {
         for vote in self.get_commit_votes() {
             vote.hash(state);
         }
+    }
+}
+
+impl Hash for PbftSealResponse {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.get_info().hash(state);
+        self.get_seal().hash(state);
     }
 }
 

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -55,9 +55,8 @@ impl Hash for PbftMessage {
 
 impl Hash for PbftSeal {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.get_previous_id().hash(state);
-        self.get_summary().hash(state);
-        for vote in self.get_previous_commit_votes() {
+        self.get_block_id().hash(state);
+        for vote in self.get_commit_votes() {
             vote.hash(state);
         }
     }
@@ -94,14 +93,13 @@ impl fmt::Display for PbftMessageInfo {
 impl fmt::Display for PbftSeal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let votes = self
-            .get_previous_commit_votes()
+            .get_commit_votes()
             .iter()
             .fold(String::new(), |acc, vote| format!("{}{}, ", acc, vote));
         write!(
             f,
-            "PbftSeal(previous_id: {}, summary: {}, votes: {})",
-            hex::encode(self.get_previous_id()),
-            hex::encode(self.get_summary()),
+            "PbftSeal(block_id: {}, votes: {})",
+            hex::encode(self.get_block_id()),
             votes,
         )
     }

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -116,19 +116,6 @@ impl ParsedMessage {
         }
     }
 
-    /// Returns the wrapped `PbftMessage`.
-    ///
-    /// # Panics
-    /// + If the wrapped message is a `NewView`, not a regular message
-    pub fn get_pbft_message(&self) -> &PbftMessage {
-        match &self.message {
-            PbftMessageWrapper::Message(m) => m,
-            PbftMessageWrapper::NewView(_) => {
-                panic!("ParsedPeerMessage.get_pbft_message found a new view message!")
-            }
-        }
-    }
-
     /// Returns the wrapped `PbftNewView`.
     ///
     /// # Panics

--- a/src/node.rs
+++ b/src/node.rs
@@ -575,7 +575,7 @@ impl PbftNode {
             self.msg_log.add_message(message.clone(), state)?;
         }
 
-        // Commit the block, stop the faulty primary timeout, and skip straight to Finished
+        // Commit the block, stop the faulty primary timeout, and skip straight to Finishing
         self.service
             .commit_block(block.previous_id.clone())
             .map_err(|err| {


### PR DESCRIPTION
Implement a procedure to commit the final block in the chain when
catching up. The standard catchup procedure does not work for this,
because it requires the seal in the next block; when the node needs to
commit the last block in the chain, there is no next block yet. The
procedure works as follows:
- When a node as caught up to the 2nd-to-last block, it broadcasts a
`SealRequest` message to the network.
- When the up-to-date nodes receive the `SealRequest`, they build a
seal, package it up in a `SealResponse` message, and send the message
directly to the node that requested it.
- When the requesting node receives a `SealResponse` (it only needs one
and will ignore the others), it validates the seal and uses it to commit
the final block.

Signed-off-by: Logan Seeley <seeley@bitwise.io>