### PR TITLE
Try again service calls

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ extern crate log;
 extern crate serde_derive;
 
 use std::process;
+use std::time::Duration;
 
 use clap::{clap_app, crate_version};
 use log4rs::append::console::ConsoleAppender;
@@ -85,6 +86,12 @@ fn main() {
     info!("Sawtooth PBFT Engine ({})", env!("CARGO_PKG_VERSION"));
 
     let mut pbft_config = config::PbftConfig::default();
+    if let Some(base) = args.exponential_retry_base {
+        pbft_config.exponential_retry_base = Duration::from_millis(base);
+    }
+    if let Some(max) = args.exponential_retry_max {
+        pbft_config.exponential_retry_max = Duration::from_secs(max);
+    }
 
     let pbft_engine = engine::PbftEngine::new(pbft_config);
 
@@ -123,7 +130,11 @@ fn parse_args() -> PbftCliArgs {
         (@arg verbose: -v --verbose +multiple
          "increase output verbosity")
         (@arg logconfig: -L --log_config +takes_value
-         "path to logging config file"))
+         "path to logging config file")
+        (@arg exponential_retry_base: -b --exponential_retry_base +takes_value
+         "base timeout for exponential backoff (milliseconds)")
+        (@arg exponential_retry_max: -m --exponential_retry_max +takes_value
+         "max timeout for exponential backoff (seconds)"))
     .get_matches();
 
     let log_config = matches.value_of("logconfig").map(|s| s.into());
@@ -141,15 +152,31 @@ fn parse_args() -> PbftCliArgs {
             .unwrap_or("tcp://localhost:5050"),
     );
 
+    let exponential_retry_base = matches
+        .value_of("exponential_retry_base")
+        .unwrap_or("")
+        .parse::<u64>()
+        .ok();
+    let exponential_retry_max = matches
+        .value_of("exponential_retry_max")
+        .unwrap_or("")
+        .parse::<u64>()
+        .ok();
+
     PbftCliArgs {
         log_config,
         log_level,
         endpoint,
+        exponential_retry_base,
+        exponential_retry_max,
     }
 }
 
+#[derive(Clone)]
 pub struct PbftCliArgs {
     log_config: Option<String>,
     log_level: log::LevelFilter,
     endpoint: String,
+    exponential_retry_base: Option<u64>,
+    exponential_retry_max: Option<u64>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,9 @@ fn main() {
 
     info!("Sawtooth PBFT Engine ({})", env!("CARGO_PKG_VERSION"));
 
-    let pbft_engine = engine::PbftEngine::new();
+    let mut pbft_config = config::PbftConfig::default();
+
+    let pbft_engine = engine::PbftEngine::new(pbft_config);
 
     let (driver, _stop) = ZmqDriver::new();
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -120,6 +120,12 @@ pub struct PbftState {
     /// node starts a change to view v + 2, the timeout will be `2 * view_change_duration`; etc.
     pub view_change_duration: Duration,
 
+    /// The base time to use for retrying with exponential backoff
+    pub exponential_retry_base: Duration,
+
+    /// The maximum time for retrying with exponential backoff
+    pub exponential_retry_max: Duration,
+
     /// How many blocks to commit before forcing a view change for fairness
     pub forced_view_change_period: u64,
 }
@@ -148,6 +154,8 @@ impl PbftState {
             faulty_primary_timeout: Timeout::new(config.faulty_primary_timeout),
             view_change_timeout: Timeout::new(config.view_change_duration),
             view_change_duration: config.view_change_duration,
+            exponential_retry_base: config.exponential_retry_base,
+            exponential_retry_max: config.exponential_retry_max,
             forced_view_change_period: config.forced_view_change_period,
         }
     }


### PR DESCRIPTION
Adds the `retry_until_ok` function to the timing module, which takes a callback, a base `Duration`, and a max `Duration` as arguments; the function will repeatedly call the callback until it returns successfully (`Ok` result) using exponential backoff (the base timeout is doubled every time the callback fails, up to the maximum timeout).

The `retry_until_ok` method is used whenever `service.get_settings` is called. The base value is determined by the `exponential_retry_base` config/state field (milliseconds) and max is determined by `exponential_retry_max` (seconds); these can be configured using the `sawtooth.consensus.pbft.exponential_retry_base` and `sawtooth.consensus.pbft.exponential_retry_max` on-chain settings, respectively.

Signed-off-by: Logan Seeley <seeley@bitwise.io>