### PR TITLE
Fix seal voters list

### DIFF
--- a/protos/pbft_message.proto
+++ b/protos/pbft_message.proto
@@ -75,7 +75,10 @@ message PbftSeal {
   // ID of the block this seal verifies
   bytes block_id = 1;
 
+  // ID of the previous block
+  bytes previous_id = 2;
+
   // A list of Commit votes to prove the block commit (must contain at least 2f
   // votes)
-  repeated PbftSignedVote commit_votes = 2;
+  repeated PbftSignedVote commit_votes = 3;
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -73,7 +73,12 @@ impl Engine for PbftEngine {
 
         let mut working_ticker = timing::Ticker::new(self.config.block_duration);
 
-        let mut node = PbftNode::new(&self.config, service, pbft_state.read().is_primary());
+        let mut node = PbftNode::new(
+            &self.config,
+            chain_head,
+            service,
+            pbft_state.read().is_primary(),
+        );
 
         node.start_faulty_primary_timeout(&mut pbft_state.write());
 

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -226,7 +226,7 @@ impl PbftLog {
                 .retain(|msg| msg.info().get_seq_num() >= current_seq_num - 1);
 
             self.blocks
-                .retain(|block| block.block_num >= current_seq_num);
+                .retain(|block| block.block_num >= current_seq_num - 1);
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -870,15 +870,14 @@ impl PbftNode {
             // therefore can't be included in the seal
             .filter(|msg| !msg.from_self)
             .cloned()
-            // Map to (view, msg) pairs
-            .map(|msg| (msg.info().get_view(), msg))
-            // Group messages together by view
+            // Map to ((block_id, view), msg)
+            .map(|msg| ((msg.get_block_id(), msg.info().get_view()), msg))
+            // Group messages together by block and view
             .into_group_map()
             .into_iter()
-            // One and only one view should have the required number of messages, since the block
-            // at this sequence number should only have been committed once and therefore in only
-            // one view
-            .find_map(|(_view, msgs)| {
+            // One and only one block/view should have the required number of messages, since only
+            // one block at this sequence number should have been committed and in only one view
+            .find_map(|((_block_id, _view), msgs)| {
                 if msgs.len() as u64 >= 2 * state.f {
                     Some(msgs)
                 } else {

--- a/src/node.rs
+++ b/src/node.rs
@@ -911,7 +911,7 @@ impl PbftNode {
             })
             .ok_or_else(|| {
                 PbftError::InternalError(String::from(
-                    "Couldn't find 2f commit messages in the message log for building a seal!",
+                    "Couldn't find 2f commit messages in the message log for building a seal",
                 ))
             })?;
 


### PR DESCRIPTION
To verify the consensus seal, we need to make sure that the votes in the
seal are all from nodes that were members of the network at the time the
block was voted on. Specifically, this means that all voters should be
in the on-chain list of peers in the block prior to the one the seal
verifies.

Before this commit, the list of voters was being taken from the block
the seal verifies itself, which is incorrect. To fix this, we add the
`previous_id` field to the consensus seal when it is built, verify that
the previous ID matches the previous ID of the block when validating the
seal, and get the list of peers using the previous ID.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

Also includes some other fixes that support this change.

Based on #85 