### PR TITLE
Fix liveness bug

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,11 @@ pub struct PbftConfig {
     /// Should be longer than block_duration
     pub faulty_primary_timeout: Duration,
 
+    /// How long to wait (after Pre-Preparing) for the node to commit the block before starting a
+    /// view change (guarantees liveness by allowing the network to get "unstuck" if something goes
+    // wrong)
+    pub commit_timeout: Duration,
+
     /// When view changing, how long to wait for a valid NewView message before starting a
     /// different view change
     pub view_change_duration: Duration,
@@ -75,6 +80,7 @@ impl PbftConfig {
             exponential_retry_base: Duration::from_millis(100),
             exponential_retry_max: Duration::from_secs(60),
             faulty_primary_timeout: Duration::from_secs(30),
+            commit_timeout: Duration::from_secs(30),
             view_change_duration: Duration::from_secs(5),
             forced_view_change_period: 30,
             max_log_size: 1000,
@@ -88,6 +94,7 @@ impl PbftConfig {
     /// + `sawtooth.consensus.pbft.peers` (required)
     /// + `sawtooth.consensus.pbft.block_duration` (optional, default 200 ms)
     /// + `sawtooth.consensus.pbft.faulty_primary_timeout` (optional, default 30s)
+    /// + `sawtooth.consensus.pbft.commit_timeout` (optional, default 30s)
     /// + `sawtooth.consensus.pbft.view_change_duration` (optional, default 5s)
     /// + `sawtooth.consensus.pbft.forced_view_change_period` (optional, default 30 blocks)
     /// + `sawtooth.consensus.pbft.message_timeout` (optional, default 10 ms)
@@ -109,6 +116,7 @@ impl PbftConfig {
                         String::from("sawtooth.consensus.pbft.peers"),
                         String::from("sawtooth.consensus.pbft.block_duration"),
                         String::from("sawtooth.consensus.pbft.faulty_primary_timeout"),
+                        String::from("sawtooth.consensus.pbft.commit_timeout"),
                         String::from("sawtooth.consensus.pbft.view_change_duration"),
                         String::from("sawtooth.consensus.pbft.forced_view_change_period"),
                         String::from("sawtooth.consensus.pbft.message_timeout"),
@@ -139,6 +147,11 @@ impl PbftConfig {
             &settings,
             &mut self.faulty_primary_timeout,
             "sawtooth.consensus.pbft.faulty_primary_timeout",
+        );
+        merge_secs_setting_if_set(
+            &settings,
+            &mut self.commit_timeout,
+            "sawtooth.consensus.pbft.commit_timeout",
         );
         merge_secs_setting_if_set(
             &settings,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -103,6 +103,12 @@ impl Engine for PbftEngine {
                     log_any_error(node.start_view_change(state, state.view + 1));
                 }
 
+                // If the commit timeout has expired, initiate a view change
+                if node.check_commit_timeout_expired(state) {
+                    warn!("Commit timeout expired; proposing view change");
+                    log_any_error(node.start_view_change(state, state.view + 1));
+                }
+
                 // Check the view change timeout if the node is view changing so we can start a new
                 // view change if we don't get a NewView in time
                 if let PbftMode::ViewChanging(v) = state.mode {

--- a/src/state.rs
+++ b/src/state.rs
@@ -111,6 +111,10 @@ pub struct PbftState {
     /// node will initiate a view change.
     pub faulty_primary_timeout: Timeout,
 
+    /// Timer used to make sure the network doesn't get stuck when it fails to commit a block. If
+    /// it does get stuck, this node will initiate a view change when the timer expires.
+    pub commit_timeout: Timeout,
+
     /// When view changing, timer is used to make sure a valid NewView message is sent by the new
     /// primary in a timely manner. If not, this node will start a different view change.
     pub view_change_timeout: Timeout,
@@ -152,6 +156,7 @@ impl PbftState {
             f,
             peer_ids: config.peers.clone(),
             faulty_primary_timeout: Timeout::new(config.faulty_primary_timeout),
+            commit_timeout: Timeout::new(config.commit_timeout),
             view_change_timeout: Timeout::new(config.view_change_duration),
             view_change_duration: config.view_change_duration,
             exponential_retry_base: config.exponential_retry_base,


### PR DESCRIPTION
This commit essentially reverts some of the changes in 65466d. The
`commit_timeout`, which ensures the a block gets committed within a
specified time, allows the network to get itself "unstuck" if something
goes wrong during the commit process. This differs slightly from the
`commit_timeout` that was removed in commit 65466d; specifically, the
timer is stopped when the node decides to commit the block rather than
after the block has been committed and the engine receives the
notificaiton from the validator.

Signed-off-by: Logan Seeley <seeley@bitwise.io>