### PR TITLE
Doc: Rewrite PBFT introduction

### DIFF
--- a/docs/source/introduction-to-sawtooth-pbft.rst
+++ b/docs/source/introduction-to-sawtooth-pbft.rst
@@ -1,38 +1,52 @@
-*****************************
-Introduction to Sawtooth PBFT
-*****************************
+************
+Introduction
+************
 
-This guide describes a practical Byzantine fault tolerant (PBFT) consensus
-algorithm for `Hyperledger Sawtooth
-<https://github.com/hyperledger/sawtooth-core>`__.
+Sawtooth PBFT is a consensus engine for Hyperledger Sawtooth that provides
+practical Byzantine fault tolerance.
 
+PBFT is a voting-based consensus algorithm that is:
+
+* Byzantine fault tolerant: Network `liveness and safety
+  <https://en.wikipedia.org/wiki/Liveness#Liveness_and_safety>`__
+  are guaranteed even when some nodes are faulty or malicious, as long as a
+  minimum percentage of nodes are connected, working properly, and behaving
+  honestly.
+
+* Non-forking: Blocks committed by nodes are final, unlike lottery-style
+  consensus algorithms such as Proof of Work (PoW) or Proof of Elapsed Time
+  (PoET).
+
+* Leader-based: A `primary node` is responsible for producing candidate blocks;
+  `secondary nodes` vote on the blocks produced by the primary. The leader
+  changes in a round-robin (circular) order.
+
+* Communication-intensive: Nodes send many messages to reach consensus, commit
+  blocks, and maintain a healthy leader node.
+
+A Sawtooth PBFT network does not support open enrollment, but nodes can be added
+and removed by an administrator. Full peering is required (all nodes must be
+connected to all other nodes). In order to provide Byzantine fault tolerance, a
+PBFT network must have a least four nodes.
+
+Sawtooth PBFT is based on the methodology described in
 `Practical Byzantine Fault Tolerance
-<https://www.usenix.org/legacy/events/osdi99/full_papers/castro/castro_html/castro.html>`__,
-a paper written in 1999 by Miguel Castro and Barbara Liskov, describes a
-consensus algorithm that solves the `Byzantine Generals Problem
-<https://en.wikipedia.org/wiki/Byzantine_fault_tolerance#Byzantine_Generals'_Problem>`__,
-while still remaining computationally feasible. This implementation of PBFT
-consensus for Hyperledger Sawtooth is based off the methodology described in
-the 1999 paper, and adapted for use in a blockchain context.
+<https://www.usenix.org/legacy/events/osdi99/full_papers/castro/castro_html/castro.html>`__
+by Miguel Castro and Barbara Liskov.
+This implementation has been adapted for use in a blockchain context; it
+includes extensions such as regular `view changes` (leader changes) and
+a `consensus seal` to verify block finality.
 
-The Sawtooth PBFT algorithm is a voting-based consensus mechanism with
-Byzantine fault tolerance. This algorithm ensures `safety and liveness
-<https://en.wikipedia.org/wiki/Liveness#Liveness_and_safety>`__ of a network,
-provided at most :math:`\lfloor \frac{n - 1}{3} \rfloor` nodes are faulty, where
-:math:`n` is the total number of nodes in the network. The Sawtooth PBFT
-algorithm is also inherently crash fault tolerant. Another advantage of PBFT
-is that blocks committed by nodes are final, so there are no forks in the
-network. This is verified by a "Consensus Seal," which is appended to the
-following block and used to verify that the block was added correctly.
-
-For implementation details, see the `Sawtooth PBFT rustdocs
+For implementation details, see the `rustdoc for Sawtooth PBFT
 <https://sawtooth.hyperledger.org/docs/pbft/nightly/master/pbft_doc/pbft_engine/index.html>`__.
 
 .. note::
 
    Sawtooth PBFT is currently a prototype. For project status, see
    `README.md <https://github.com/hyperledger/sawtooth-pbft/blob/master/README.md>`__
-   in the `Sawtooth PBFT repository <https://github.com/hyperledger/sawtooth-pbft>`__.
+   in the
+   `Sawtooth PBFT repository <https://github.com/hyperledger/sawtooth-pbft>`__.
+
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
- Describe PBFT at a higher level
- List the general characteristics of PBFT consensus
- Explain that PBFT networks don't allow open enrollment but admins can add nodes
- Mention some Sawtooth PBFT extensions (consensus seal and regular view changes)
- Clarify rustdoc wording

The math-heavy details will move to the Architecture section in a separate commit.

Signed-off-by: Anne Chenette <chenette@bitwise.io>