### PR TITLE
Fix bug causing node to get stuck in ViewChanging

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -727,8 +727,7 @@ impl PbftNode {
             });
         }
 
-        // Update state to be ready for next block
-        state.switch_phase(PbftPhase::PrePreparing)?;
+        // Update sequence number
         state.seq_num += 1;
 
         // If node(s) are waiting for a seal to commit the last block, send it now
@@ -773,8 +772,9 @@ impl PbftNode {
             return self.request_final_seal(state);
         }
 
-        // Restart the faulty primary timeout for the next block
-        state.faulty_primary_timeout.start();
+        // Restart to the beginning of the algorithm (Normal mode, PrePreparing phase) and start
+        // the faulty primary timeout for the next block
+        state.reset_to_start();
 
         // If we already have a block at this sequence number with a valid PrePrepare for it, start
         // Preparing (there may be multiple blocks, but only one will have a valid PrePrepare)

--- a/src/state.rs
+++ b/src/state.rs
@@ -219,7 +219,8 @@ impl PbftState {
         self.seq_num > 0 && self.seq_num % self.forced_view_change_period == 0
     }
 
-    /// Reset the phase and mode, restart the timers; used after a view change has occured
+    /// Reset the phase and mode, restart the faulty primary timer; used to "restart" the algorithm
+    /// when a view change occurs or a block is committed.
     pub fn reset_to_start(&mut self) {
         info!("Resetting state: {}", self);
         self.phase = PbftPhase::PrePreparing;


### PR DESCRIPTION
This fixes a bug where a node would get stuck in the `ViewChanging`
mode. The node would be able to continue to commit blocks using
catch-up, but would ignore all normal PBFT messages since it was in the
`ViewChanging` mode. This is fixed by always making sure the mode is set
to `Normal` when a block gets committed.

Signed-off-by: Logan Seeley <seeley@bitwise.io>