### PR TITLE
Re-implement guarded PrePrepare broadcasting

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -571,7 +571,7 @@ impl PbftNode {
         if block.block_num > state.seq_num && !is_waiting {
             self.catchup(state, &seal, true)?;
         } else if block.block_num == state.seq_num {
-            if state.is_primary() {
+            if block.signer_id == state.id && state.is_primary() {
                 // This is the next block and this node is the primary; broadcast PrePrepare
                 // messages
                 info!("Broadcasting PrePrepares");


### PR DESCRIPTION
This re-implements commit 52a5f3, which was inadvertently reverted.

Before broadcasting a PrePrepare to the network when a BlockNew for the
current sequence number is received, the primary must check to make sure
that the block was the one it just created (the `signer_id` of the block
should match the node's own ID). This prevents the primary from
incorrectly broadcasting a PrePrepare if another node were to publish a
block.

Signed-off-by: Logan Seeley <seeley@bitwise.io>