### PR TITLE
Add signed bytes when parsing messages from seal

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -607,12 +607,8 @@ impl PbftNode {
         let messages = seal
             .get_commit_votes()
             .iter()
-            .try_fold(Vec::new(), |mut msgs, v| {
-                msgs.push(ParsedMessage::from_pbft_message(
-                    protobuf::parse_from_bytes(&v.get_message_bytes()).map_err(|err| {
-                        PbftError::SerializationError("Error parsing commit vote".into(), err)
-                    })?,
-                ));
+            .try_fold(Vec::new(), |mut msgs, vote| {
+                msgs.push(ParsedMessage::from_signed_vote(vote)?);
                 Ok(msgs)
             })?;
 


### PR DESCRIPTION
As part of the catch-up procedure, the node extracts all of the votes
from a valid consensus seal and adds them to its log. If the node does
this for the last block and then becomes the leader through a view
change, it will need to produce a valid consensus seal for this block.
Previously, the messages were parsed and added to the log without the
signed components, so the new seal wouldn't contain validly signed
votes. To fix this, `ParsedMessage`s can now be constructed from
`PbftSignedVote`s using the `ParsedMessage::from_signed_vote` method,
which sets the signed components of the `ParsedMessage`. The
`PbftNode::catchup` method now uses this constructor when parsing
messages from the seal.

Signed-off-by: Logan Seeley <seeley@bitwise.io>