### PR TITLE
Improve seal verification

### DIFF
--- a/protos/pbft_message.proto
+++ b/protos/pbft_message.proto
@@ -69,10 +69,7 @@ message PbftSeal {
   // ID of the block this seal verifies
   bytes block_id = 2;
 
-  // ID of the previous block
-  bytes previous_id = 3;
-
   // A list of Commit votes to prove the block commit (must contain at least 2f
   // votes)
-  repeated PbftSignedVote commit_votes = 4;
+  repeated PbftSignedVote commit_votes = 3;
 }

--- a/protos/pbft_message.proto
+++ b/protos/pbft_message.proto
@@ -72,13 +72,16 @@ message PbftSignedVote {
 }
 
 message PbftSeal {
+  // Message information
+  PbftMessageInfo info = 1;
+
   // ID of the block this seal verifies
-  bytes block_id = 1;
+  bytes block_id = 2;
 
   // ID of the previous block
-  bytes previous_id = 2;
+  bytes previous_id = 3;
 
   // A list of Commit votes to prove the block commit (must contain at least 2f
   // votes)
-  repeated PbftSignedVote commit_votes = 3;
+  repeated PbftSignedVote commit_votes = 4;
 }

--- a/protos/pbft_message.proto
+++ b/protos/pbft_message.proto
@@ -51,15 +51,6 @@ message PbftNewView {
   repeated PbftSignedVote view_changes = 2;
 }
 
-// A message sent to a node that has requested a seal for finishing catch-up
-message PbftSealResponse {
-  // Message information
-  PbftMessageInfo info = 1;
-
-  // The requested seal
-  PbftSeal seal = 2;
-}
-
 message PbftSignedVote {
   // Serialized ConsensusPeerMessage header
   bytes header_bytes = 1;

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -57,7 +57,6 @@ impl Hash for PbftSeal {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.get_info().hash(state);
         self.get_block_id().hash(state);
-        self.get_previous_id().hash(state);
         for vote in self.get_commit_votes() {
             vote.hash(state);
         }

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -56,6 +56,7 @@ impl Hash for PbftMessage {
 
 impl Hash for PbftSeal {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        self.get_info().hash(state);
         self.get_block_id().hash(state);
         self.get_previous_id().hash(state);
         for vote in self.get_commit_votes() {
@@ -107,7 +108,8 @@ impl fmt::Display for PbftSeal {
             .fold(String::new(), |acc, vote| format!("{}{}, ", acc, vote));
         write!(
             f,
-            "PbftSeal(block_id: {}, votes: {})",
+            "PbftSeal(info: {}, block_id: {}, votes: {})",
+            self.get_info(),
             hex::encode(self.get_block_id()),
             votes,
         )

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -30,12 +30,11 @@ use sawtooth_sdk::messages::consensus::ConsensusPeerMessageHeader;
 
 use crate::message_type::PbftMessageType;
 use crate::protos::pbft_message::{
-    PbftMessage, PbftMessageInfo, PbftNewView, PbftSeal, PbftSealResponse, PbftSignedVote,
+    PbftMessage, PbftMessageInfo, PbftNewView, PbftSeal, PbftSignedVote,
 };
 
 impl Eq for PbftMessage {}
 impl Eq for PbftSeal {}
-impl Eq for PbftSealResponse {}
 impl Eq for PbftNewView {}
 
 impl Hash for PbftMessageInfo {
@@ -62,13 +61,6 @@ impl Hash for PbftSeal {
         for vote in self.get_commit_votes() {
             vote.hash(state);
         }
-    }
-}
-
-impl Hash for PbftSealResponse {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.get_info().hash(state);
-        self.get_seal().hash(state);
     }
 }
 

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -57,6 +57,7 @@ impl Hash for PbftMessage {
 impl Hash for PbftSeal {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.get_block_id().hash(state);
+        self.get_previous_id().hash(state);
         for vote in self.get_commit_votes() {
             vote.hash(state);
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1190,10 +1190,27 @@ impl PbftNode {
                 .iter()
                 .try_fold(HashSet::new(), |mut ids, vote| {
                     Self::verify_vote(vote, PbftMessageType::Commit, |msg| {
+                        // Make sure all votes are for the right block
                         if msg.block_id != seal.block_id {
                             return Err(PbftError::InvalidMessage(format!(
                                 "Commit vote's block ID ({:?}) doesn't match seal's ID ({:?})",
                                 msg.block_id, seal.block_id
+                            )));
+                        }
+                        // Make sure all votes are for the right view
+                        if msg.get_info().get_view() != seal.get_info().get_view() {
+                            return Err(PbftError::InvalidMessage(format!(
+                                "Commit vote's view ({:?}) doesn't match seal's view ({:?})",
+                                msg.get_info().get_view(),
+                                seal.get_info().get_view()
+                            )));
+                        }
+                        // Make sure all votes are for the right sequence number
+                        if msg.get_info().get_seq_num() != seal.get_info().get_seq_num() {
+                            return Err(PbftError::InvalidMessage(format!(
+                                "Commit vote's seq_num ({:?}) doesn't match seal's seq_num ({:?})",
+                                msg.get_info().get_seq_num(),
+                                seal.get_info().get_seq_num()
                             )));
                         }
                         Ok(())


### PR DESCRIPTION
- Add message info (message type, view, sequence number, and signer ID) to consensus seal
- Get rid of `PbftSealResponse` in favor of using the `PbftSeal` itself
- Verify implicit seal vote, view, and sequence number using the info in a seal