### PR TITLE
Enforce block number <-> sequence number equivalence

### DIFF
--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -84,7 +84,7 @@ impl PbftLog {
     }
 
     /// Get all `Block`s in the message log with the specified block number
-    pub fn get_blocks(&self, block_num: u64) -> Vec<&Block> {
+    pub fn get_blocks_with_num(&self, block_num: u64) -> Vec<&Block> {
         self.blocks
             .iter()
             .filter(|block| block.block_num == block_num)

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -91,11 +91,11 @@ impl PbftLog {
             .collect()
     }
 
-    /// Check if the log contains a block with the specified block ID
-    pub fn has_block(&self, block_id: &[u8]) -> bool {
+    /// Get the `Block` with the specified block ID
+    pub fn get_block_with_id(&self, block_id: &[u8]) -> Option<&Block> {
         self.blocks
             .iter()
-            .any(|block| block.block_id.as_slice() == block_id)
+            .find(|block| block.block_id.as_slice() == block_id)
     }
 
     /// Add a parsed PBFT message to the log

--- a/src/node.rs
+++ b/src/node.rs
@@ -531,7 +531,11 @@ impl PbftNode {
         // verified without it; the node has the previous block if 1) this block is for the current
         // sequence number (previous block is already committed), or 2) the previous block is in
         // the log
-        if block.block_num != state.seq_num && !self.msg_log.has_block(block.previous_id.as_slice())
+        if block.block_num != state.seq_num
+            && self
+                .msg_log
+                .get_block_with_id(block.previous_id.as_slice())
+                .is_none()
         {
             self.service
                 .fail_block(block.block_id.clone())
@@ -849,7 +853,7 @@ impl PbftNode {
     /// Prepare
     fn try_preparing(&mut self, block_id: BlockId, state: &mut PbftState) -> Result<(), PbftError> {
         if state.phase == PbftPhase::PrePreparing
-            && self.msg_log.has_block(&block_id)
+            && self.msg_log.get_block_with_id(&block_id).is_some()
             && self.msg_log.has_pre_prepare(state, &block_id)
         {
             state.switch_phase(PbftPhase::Preparing)?;

--- a/src/node.rs
+++ b/src/node.rs
@@ -534,17 +534,30 @@ impl PbftNode {
         // verified without it; the node has the previous block if 1) this block is for the current
         // sequence number (previous block is already committed), or 2) the previous block is in
         // the log
-        if block.block_num != state.seq_num
-            && self
-                .msg_log
-                .get_block_with_id(block.previous_id.as_slice())
-                .is_none()
-        {
+        let previous_block = self.msg_log.get_block_with_id(block.previous_id.as_slice());
+
+        if block.block_num != state.seq_num && previous_block.is_none() {
             self.service
                 .fail_block(block.block_id.clone())
                 .unwrap_or_else(|err| error!("Couldn't fail block due to error: {:?}", err));
             return Err(PbftError::InternalError(format!(
-                "Received block {:?} / {:?} but node does not have previous block {:?} / {:?}",
+                "Received block {:?} / {:?} but node does not have previous block {:?}",
+                block.block_num,
+                hex::encode(&block.block_id),
+                hex::encode(&block.previous_id),
+            )));
+        }
+
+        // Make sure that the previous block has the previous block number (enforces that blocks
+        // are strictly monotically increasing by 1)
+        let previous_block = previous_block.expect("Previous block's existence already checked");
+        if previous_block.block_num != block.block_num - 1 {
+            self.service
+                .fail_block(block.block_id.clone())
+                .unwrap_or_else(|err| error!("Couldn't fail block due to error: {:?}", err));
+            return Err(PbftError::InternalError(format!(
+                "Received block {:?} / {:?} but its previous block ({:?} / {:?}) does not have \
+                 the previous block_num",
                 block.block_num,
                 hex::encode(&block.block_id),
                 block.block_num - 1,
@@ -855,19 +868,28 @@ impl PbftNode {
     /// and it is in the PrePreparing phase, it can enter the Preparing phase and broadcast its
     /// Prepare
     fn try_preparing(&mut self, block_id: BlockId, state: &mut PbftState) -> Result<(), PbftError> {
-        if state.phase == PbftPhase::PrePreparing
-            && self.msg_log.get_block_with_id(&block_id).is_some()
-            && self.msg_log.has_pre_prepare(state, &block_id)
-        {
-            state.switch_phase(PbftPhase::Preparing)?;
+        if let Some(block) = self.msg_log.get_block_with_id(&block_id) {
+            if state.phase == PbftPhase::PrePreparing
+                && self.msg_log.has_pre_prepare(state, &block_id)
+                // PrePrepare.seq_num == state.seq_num == block.block_num enforces the one-to-one
+                // correlation between seq_num and block_num (PrePrepare n should be for block n)
+                && block.block_num == state.seq_num
+            {
+                state.switch_phase(PbftPhase::Preparing)?;
 
-            // Stop view change timer, since a new block and valid PrePrepare were received in time
-            state.faulty_primary_timeout.stop();
+                // Stop view change timer, since a new block and valid PrePrepare were received in time
+                state.faulty_primary_timeout.stop();
 
-            // Now start the commit timeout in case something goes wrong
-            state.commit_timeout.start();
+                // Now start the commit timeout in case something goes wrong
+                state.commit_timeout.start();
 
-            self._broadcast_pbft_message(state.seq_num, PbftMessageType::Prepare, block_id, state)?;
+                self._broadcast_pbft_message(
+                    state.seq_num,
+                    PbftMessageType::Prepare,
+                    block_id,
+                    state,
+                )?;
+            }
         }
 
         Ok(())

--- a/src/node.rs
+++ b/src/node.rs
@@ -467,7 +467,7 @@ impl PbftNode {
         // that the seal's previous ID matches the previous ID of the block
         if let Some(block) = self
             .msg_log
-            .get_blocks(state.seq_num)
+            .get_blocks_with_num(state.seq_num)
             .iter()
             .find(|block| block.block_id == seal.block_id)
         {
@@ -710,7 +710,7 @@ impl PbftNode {
         // just committed, reject them
         let invalid_block_ids = self
             .msg_log
-            .get_blocks(state.seq_num)
+            .get_blocks_with_num(state.seq_num)
             .iter()
             .filter_map(|block| {
                 if block.block_id != block_id {
@@ -762,7 +762,7 @@ impl PbftNode {
         // perform catch-up
         let block_option = self
             .msg_log
-            .get_blocks(state.seq_num + 1)
+            .get_blocks_with_num(state.seq_num + 1)
             .first()
             .cloned()
             .cloned();
@@ -784,7 +784,7 @@ impl PbftNode {
         // Preparing (there may be multiple blocks, but only one will have a valid PrePrepare)
         let block_ids = self
             .msg_log
-            .get_blocks(state.seq_num)
+            .get_blocks_with_num(state.seq_num)
             .iter()
             .map(|block| block.block_id.clone())
             .collect::<Vec<_>>();
@@ -925,7 +925,7 @@ impl PbftNode {
 
         let previous_id = self
             .msg_log
-            .get_blocks(state.seq_num - 1)
+            .get_blocks_with_num(state.seq_num - 1)
             .iter()
             .find_map(|block| {
                 if block.block_id == block_id {
@@ -1131,7 +1131,7 @@ impl PbftNode {
         // Make sure the seal's previous ID matches the previous ID of the block it verifies
         let verified_block = self
             .msg_log
-            .get_blocks(block.block_num - 1)
+            .get_blocks_with_num(block.block_num - 1)
             .iter()
             .find(|log_block| log_block.block_id == seal.block_id)
             .cloned()


### PR DESCRIPTION
Enforces that any block committed at sequence number n has block_num = n. This is enforced by requiring that:
1. The previous block of block n has block_num = n - 1 (this means that the block numbers of all blocks in the chain, just like sequence numbers, are strictly monotonically increasing by one)
2. The block referenced by a PrePrepare for sequence number n has block_num = n (this means that there is a strict one-to-one correlation between the sequence number and the block number)

Also updates the methods used to retrieve blocks from the log.