### PR TITLE
Fix double-broadcasting bug for NewViews

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -323,7 +323,8 @@ impl PbftNode {
                 "{}: Received f + 1 ViewChange messages; starting early view change",
                 state
             );
-            self.start_view_change(state, msg_view)?;
+            // Can exit early since the node will self-send another ViewChange message here
+            return self.start_view_change(state, msg_view);
         }
 
         // If this node is the new primary and the required 2f ViewChange messages (not including


### PR DESCRIPTION
Fixes a bug where NewView messages would be broadcasted twice; this
happened when a new primary of a 4 node network started a view change
early when it received f + 1 ViewChange messages. Because it's a 4 node
network, f=1, so f + 1 == 2f. This means that it would self-send a
ViewChange message which would trigger a NewView broadcast, then trigger
a NewView broadcast as a result of the original message that made the
count f + 1.

This is fixed by simply returning when a view change is started early;
the NewView message will still be triggered (if necessary) by the
self-sent message without sending it twice.

Signed-off-by: Logan Seeley <seeley@bitwise.io>