### PR TITLE
Fix state reset on commit

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -218,15 +218,6 @@ impl PbftState {
     pub fn at_forced_view_change(&self) -> bool {
         self.seq_num > 0 && self.seq_num % self.forced_view_change_period == 0
     }
-
-    /// Reset the phase and mode, restart the faulty primary timer; used to "restart" the algorithm
-    /// when a view change occurs or a block is committed.
-    pub fn reset_to_start(&mut self) {
-        info!("Resetting state: {}", self);
-        self.phase = PbftPhase::PrePreparing;
-        self.mode = PbftMode::Normal;
-        self.faulty_primary_timeout.start();
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This commit fixes a bug where a node wouldn't be able to complete the
final block catch-up procedure because it didn't update it's phase
before requesting the seal (it would still be in the Finishing phase,
but when it receives the requested seal it checks if its in the
Finishing phase to make sure it doesn't commit the block twice).

Also removes the `PbftState::reset_to_start` method since it is very
simple and only used in one place now.

Signed-off-by: Logan Seeley <seeley@bitwise.io>