### PR TITLE
Rename faulty_primary_timeout to idle_timeout

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -50,7 +50,7 @@ pub struct PbftConfig {
 
     /// How long to wait for the next BlockNew + PrePrepare before determining primary is faulty
     /// Should be longer than block_duration
-    pub faulty_primary_timeout: Duration,
+    pub idle_timeout: Duration,
 
     /// How long to wait (after Pre-Preparing) for the node to commit the block before starting a
     /// view change (guarantees liveness by allowing the network to get "unstuck" if it is unable
@@ -79,7 +79,7 @@ impl PbftConfig {
             message_timeout: Duration::from_millis(10),
             exponential_retry_base: Duration::from_millis(100),
             exponential_retry_max: Duration::from_secs(60),
-            faulty_primary_timeout: Duration::from_secs(30),
+            idle_timeout: Duration::from_secs(30),
             commit_timeout: Duration::from_secs(30),
             view_change_duration: Duration::from_secs(5),
             forced_view_change_period: 30,
@@ -93,7 +93,7 @@ impl PbftConfig {
     /// Configuration loads the following settings:
     /// + `sawtooth.consensus.pbft.peers` (required)
     /// + `sawtooth.consensus.pbft.block_duration` (optional, default 200 ms)
-    /// + `sawtooth.consensus.pbft.faulty_primary_timeout` (optional, default 30s)
+    /// + `sawtooth.consensus.pbft.idle_timeout` (optional, default 30s)
     /// + `sawtooth.consensus.pbft.commit_timeout` (optional, default 30s)
     /// + `sawtooth.consensus.pbft.view_change_duration` (optional, default 5s)
     /// + `sawtooth.consensus.pbft.forced_view_change_period` (optional, default 30 blocks)
@@ -102,7 +102,7 @@ impl PbftConfig {
     /// + `sawtooth.consensus.pbft.storage` (optional, default `"memory"`)
     ///
     /// # Panics
-    /// + If block duration is greater than the faulty primary timeout
+    /// + If block duration is greater than the idle timeout
     /// + If the `sawtooth.consensus.pbft.peers` setting is not provided or is invalid
     pub fn load_settings(&mut self, block_id: BlockId, service: &mut Service) {
         debug!("Getting on-chain settings for config");
@@ -115,7 +115,7 @@ impl PbftConfig {
                     vec![
                         String::from("sawtooth.consensus.pbft.peers"),
                         String::from("sawtooth.consensus.pbft.block_duration"),
-                        String::from("sawtooth.consensus.pbft.faulty_primary_timeout"),
+                        String::from("sawtooth.consensus.pbft.idle_timeout"),
                         String::from("sawtooth.consensus.pbft.commit_timeout"),
                         String::from("sawtooth.consensus.pbft.view_change_duration"),
                         String::from("sawtooth.consensus.pbft.forced_view_change_period"),
@@ -145,8 +145,8 @@ impl PbftConfig {
         );
         merge_secs_setting_if_set(
             &settings,
-            &mut self.faulty_primary_timeout,
-            "sawtooth.consensus.pbft.faulty_primary_timeout",
+            &mut self.idle_timeout,
+            "sawtooth.consensus.pbft.idle_timeout",
         );
         merge_secs_setting_if_set(
             &settings,
@@ -159,11 +159,11 @@ impl PbftConfig {
             "sawtooth.consensus.pbft.view_change_duration",
         );
 
-        // Check to make sure block_duration < faulty_primary_timeout
-        if self.block_duration >= self.faulty_primary_timeout {
+        // Check to make sure block_duration < idle_timeout
+        if self.block_duration >= self.idle_timeout {
             panic!(
-                "Block duration ({:?}) must be less than the faulty primary timeout ({:?})",
-                self.block_duration, self.faulty_primary_timeout
+                "Block duration ({:?}) must be less than the idle timeout ({:?})",
+                self.block_duration, self.idle_timeout
             );
         }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -80,7 +80,7 @@ impl Engine for PbftEngine {
             pbft_state.read().is_primary(),
         );
 
-        node.start_faulty_primary_timeout(&mut pbft_state.write());
+        node.start_idle_timeout(&mut pbft_state.write());
 
         // Main event loop; keep going until PBFT receives a Shutdown message or is disconnected
         loop {
@@ -101,10 +101,10 @@ impl Engine for PbftEngine {
             working_ticker.tick(|| {
                 log_any_error(node.try_publish(state));
 
-                // Every so often, check to see if the faulty primary timeout has expired; initiate
+                // Every so often, check to see if the idle timeout has expired; initiate
                 // ViewChange if necessary
-                if node.check_faulty_primary_timeout_expired(state) {
-                    warn!("Faulty primary timeout expired; proposing view change");
+                if node.check_idle_timeout_expired(state) {
+                    warn!("Idle timeout expired; proposing view change");
                     log_any_error(node.start_view_change(state, state.view + 1));
                 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -106,7 +106,7 @@ pub struct PbftState {
 
     /// Timer used to make sure the primary publishes blocks in a timely manner. If not, then this
     /// node will initiate a view change.
-    pub faulty_primary_timeout: Timeout,
+    pub idle_timeout: Timeout,
 
     /// Timer used to make sure the network doesn't get stuck if it fails to commit a block in a
     /// reasonable amount of time. If it doesn't commit a block in time, this node will initiate a
@@ -153,7 +153,7 @@ impl PbftState {
             mode: PbftMode::Normal,
             f,
             peer_ids: config.peers.clone(),
-            faulty_primary_timeout: Timeout::new(config.faulty_primary_timeout),
+            idle_timeout: Timeout::new(config.idle_timeout),
             commit_timeout: Timeout::new(config.commit_timeout),
             view_change_timeout: Timeout::new(config.view_change_duration),
             view_change_duration: config.view_change_duration,


### PR DESCRIPTION
The timeout was originally called the `idle_timeout`, but was changed in
commit 65466d when the timeouts were changed; the timeouts have
essentially been reverted to their previous behavior however (with only
minor changes), so the name should be updated to more accurately reflect
its behavior again.

Signed-off-by: Logan Seeley <seeley@bitwise.io>