### PR TITLE
Fix primary prepare voting

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -222,7 +222,7 @@ impl PbftNode {
             )));
         }
 
-        self.msg_log.add_message(msg.clone());
+        self.msg_log.add_message(msg);
 
         // If this message is for the current sequence number and the node is in the Preparing
         // phase, check if the node is ready to move on to the Committing phase
@@ -233,12 +233,18 @@ impl PbftNode {
             let has_matching_pre_prepare =
                 self.msg_log
                     .has_pre_prepare(info.get_seq_num(), info.get_view(), &block_id);
-            let has_required_prepares = self.msg_log.has_required_msgs(
-                PbftMessageType::Prepare,
-                &msg,
-                true,
-                2 * state.f + 1,
-            );
+            let has_required_prepares = self
+                .msg_log
+                // Only get Prepares with matching seq_num, view, and block_id
+                .get_messages_of_type_seq_view_block(
+                    PbftMessageType::Prepare,
+                    info.get_seq_num(),
+                    info.get_view(),
+                    &block_id,
+                )
+                // Check if there are at least 2f + 1 Prepares
+                .len() as u64
+                > 2 * state.f;
             if has_matching_pre_prepare && has_required_prepares {
                 state.switch_phase(PbftPhase::Committing)?;
                 self.broadcast_pbft_message(
@@ -286,12 +292,18 @@ impl PbftNode {
             let has_matching_pre_prepare =
                 self.msg_log
                     .has_pre_prepare(info.get_seq_num(), info.get_view(), &block_id);
-            let has_required_commits = self.msg_log.has_required_msgs(
-                PbftMessageType::Commit,
-                &msg,
-                true,
-                2 * state.f + 1,
-            );
+            let has_required_commits = self
+                .msg_log
+                // Only get Commits with matching seq_num, view, and block_id
+                .get_messages_of_type_seq_view_block(
+                    PbftMessageType::Commit,
+                    info.get_seq_num(),
+                    info.get_view(),
+                    &block_id,
+                )
+                // Check if there are at least 2f + 1 Commits
+                .len() as u64
+                > 2 * state.f;
             if has_matching_pre_prepare && has_required_commits {
                 self.service.commit_block(block_id.clone()).map_err(|err| {
                     PbftError::ServiceError(
@@ -338,13 +350,18 @@ impl PbftNode {
         // f + 1 ViewChange messages in the log for this proposed view (but if already view
         // changing, only do this for a later view); this will prevent starting the view change too
         // late
-        if match state.mode {
+        let is_later_view = match state.mode {
             PbftMode::ViewChanging(v) => msg_view > v,
             PbftMode::Normal => true,
-        } && self
+        };
+        let has_required_view_changes = self
             .msg_log
-            .has_required_msgs(PbftMessageType::ViewChange, msg, false, state.f + 1)
-        {
+            // Only get ViewChanges with matching view
+            .get_messages_of_type_view(PbftMessageType::ViewChange, msg_view)
+            // Check if there are at least f + 1 ViewChanges
+            .len() as u64
+            > state.f;
+        if is_later_view && has_required_view_changes {
             info!(
                 "{}: Received f + 1 ViewChange messages; starting early view change",
                 state
@@ -1805,9 +1822,18 @@ mod tests {
             .unwrap_or_else(panic_with_err);
 
         // Verify it worked
-        assert!(node0
-            .msg_log
-            .has_required_msgs(PbftMessageType::PrePrepare, &valid_msg, true, 1));
+        assert_eq!(
+            node0
+                .msg_log
+                .get_messages_of_type_seq_view_block(
+                    PbftMessageType::PrePrepare,
+                    valid_msg.info().get_seq_num(),
+                    valid_msg.info().get_view(),
+                    &mock_block_id(1),
+                )
+                .len(),
+            1
+        );
         assert_eq!(state0.phase, PbftPhase::Preparing);
     }
 

--- a/tests/test_crash_fault_tolerance.sh
+++ b/tests/test_crash_fault_tolerance.sh
@@ -37,7 +37,9 @@ function cleanup {
     echo "-- Gamma --"
     docker-compose -p ${ISOLATION_ID}-gamma -f adhoc/node.yaml logs
     echo "-- Delta --"
-    GENESIS=1 docker-compose -p ${ISOLATION_ID}-delta -f adhoc/node.yaml logs
+    docker-compose -p ${ISOLATION_ID}-delta -f adhoc/node.yaml logs
+    echo "-- Epsilon --"
+    GENESIS=1 docker-compose -p ${ISOLATION_ID}-epsilon -f adhoc/node.yaml logs
     echo "-- Admin --"
     docker-compose -p ${ISOLATION_ID} -f adhoc/admin.yaml logs
     echo "Shutting down all containers"
@@ -45,7 +47,8 @@ function cleanup {
     docker-compose -p ${ISOLATION_ID}-alpha -f adhoc/node.yaml down --remove-orphans --volumes
     docker-compose -p ${ISOLATION_ID}-beta -f adhoc/node.yaml down --remove-orphans --volumes
     docker-compose -p ${ISOLATION_ID}-gamma -f adhoc/node.yaml down --remove-orphans --volumes
-    GENESIS=1 docker-compose -p ${ISOLATION_ID}-delta -f adhoc/node.yaml down --remove-orphans --volumes
+    docker-compose -p ${ISOLATION_ID}-delta -f adhoc/node.yaml down --remove-orphans --volumes
+    GENESIS=1 docker-compose -p ${ISOLATION_ID}-epsilon -f adhoc/node.yaml down --remove-orphans --volumes
     docker-compose -p ${ISOLATION_ID} -f adhoc/admin.yaml down --remove-orphans --volumes
 }
 
@@ -68,7 +71,8 @@ docker-compose -p ${ISOLATION_ID} -f adhoc/admin.yaml up -d
 docker-compose -p ${ISOLATION_ID}-alpha -f adhoc/node.yaml up -d
 docker-compose -p ${ISOLATION_ID}-beta -f adhoc/node.yaml up -d
 docker-compose -p ${ISOLATION_ID}-gamma -f adhoc/node.yaml up -d
-GENESIS=1 docker-compose -p ${ISOLATION_ID}-delta -f adhoc/node.yaml up -d
+docker-compose -p ${ISOLATION_ID}-delta -f adhoc/node.yaml up -d
+GENESIS=1 docker-compose -p ${ISOLATION_ID}-epsilon -f adhoc/node.yaml up -d
 
 ADMIN=${ISOLATION_ID}_admin_1
 
@@ -95,7 +99,7 @@ echo "Waiting for all nodes to reach block 10"
 docker exec ${ADMIN} bash -c '\
   APIS=$(cd /shared_data/rest_apis && ls -d *); \
   NODES_ON_10=0; \
-  until [ "$NODES_ON_10" -eq 4 ]; do \
+  until [ "$NODES_ON_10" -eq 5 ]; do \
     NODES_ON_10=0; \
     sleep 5; \
     for api in $APIS; do \
@@ -118,7 +122,7 @@ echo "Waiting for remaining nodes to reach block 20"
 docker exec ${ADMIN} bash -c '\
   APIS=$(cd /shared_data/rest_apis && ls -d *); \
   NODES_ON_20=0; \
-  until [ "$NODES_ON_20" -gt 2 ]; do \
+  until [ "$NODES_ON_20" -gt 3 ]; do \
     NODES_ON_20=0; \
     sleep 5; \
     for api in $APIS; do \
@@ -141,7 +145,7 @@ echo "Waiting for all nodes to reach block 30"
 docker exec ${ADMIN} bash -c '\
   APIS=$(cd /shared_data/rest_apis && ls -d *); \
   NODES_ON_30=0; \
-  until [ "$NODES_ON_30" -eq 4 ]; do \
+  until [ "$NODES_ON_30" -eq 5 ]; do \
     NODES_ON_30=0; \
     sleep 5; \
     for api in $APIS; do \


### PR DESCRIPTION
Fixes the Prepare voting by not allowing the primary to broadcast a
Prepare message; the primary's PrePrepare message counts as its "vote"
for the Preparing phase. If the primary were allowed to broadcast a
Prepare, it could cause nodes to diverge on the blocks they commit for a
given sequence number when the network is a certain size.

Now, a non-faulty primary will not broadcast a Prepare message, and
non-faulty secondaries will not accept Prepare messages from the
primary. This reflects the behavior of the original PBFT definition.

Signed-off-by: Logan Seeley <seeley@bitwise.io>