### PR TITLE
Allow updating view backwards on catchup commit

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -629,7 +629,7 @@ impl PbftNode {
 
         // Update view if necessary
         let view = messages[0].info().get_view();
-        if view > state.view {
+        if view != state.view {
             info!("Updating view from {} to {}", state.view, view);
             state.view = view;
         }


### PR DESCRIPTION
When a node starts up and needs to catch-up from a long way back, it may
trigger view changes such that it is on a later view than the one the
blocks it commits were committed at. In this case, the node should be
able to correct itself and adopt the views in which the blocks were
committed.

Signed-off-by: Logan Seeley <seeley@bitwise.io>