### PR TITLE
Fix bug with view change while waiting for commit

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -436,9 +436,15 @@ impl PbftNode {
 
         info!("{}: Updated to view {}", state, state.view);
 
-        // Reset state to beginning of Normal mode and restart idle timeout
+        // Reset state to Normal mode, reset the phase (unless waiting for a BlockCommit) and
+        // restart the idle timeout
         state.mode = PbftMode::Normal;
-        state.phase = PbftPhase::PrePreparing;
+        if match state.phase {
+            PbftPhase::Finishing(_) => false,
+            _ => true,
+        } {
+            state.phase = PbftPhase::PrePreparing;
+        }
         state.idle_timeout.start();
 
         // Initialize a new block if this node is the new primary

--- a/src/node.rs
+++ b/src/node.rs
@@ -93,7 +93,7 @@ impl PbftNode {
         if !state.peer_ids.contains(&msg.info().signer_id) {
             return Err(PbftError::InvalidMessage(format!(
                 "Received message from node ({:?}) that is not a known peer",
-                msg.info().get_signer_id(),
+                hex::encode(msg.info().get_signer_id()),
             )));
         }
 


### PR DESCRIPTION
This fixes a bug where while a node is waiting for a BlockCommit update
from the validator, it switches views and resets the phase to
`PrePreparing`. Even after a view change is completed, the node should
still wait for the BlockCommit notification before attempting to process
other blocks.

Signed-off-by: Logan Seeley <seeley@bitwise.io>