### PR TITLE
Make aborted and failed builds more obvious

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,5 +160,11 @@ pipeline {
         success {
             archiveArtifacts 'build/*.deb, docs/build/html/**, docs/build/latex/*.pdf'
         }
+        aborted {
+            error "Aborted, exiting now"
+        }
+        failure {
+            error "Failed, exiting now"
+        }
     }
 }


### PR DESCRIPTION
The devmode Jenkinsfile does this already.

Signed-off-by: Richard Berg <rberg@bitwise.io>