### PR TITLE
Fix from_self value of ParsedMessages from peers

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -156,7 +156,7 @@ fn handle_update(
             // ensured that the PbftMessage was in fact created and signed by the node that it
             // claims to be from by comparing the header's signer and the PbftMessage's signer
             let verified_signer_id = message.header.signer_id.clone();
-            let parsed_message = ParsedMessage::from_peer_message(message)?;
+            let parsed_message = ParsedMessage::from_peer_message(message, state.id.as_slice())?;
             let pbft_signer_id = parsed_message.info().get_signer_id().to_vec();
 
             if pbft_signer_id != verified_signer_id {


### PR DESCRIPTION
Previously, when a PeerMessage was parsed, it was assumed that the
message came from another node. However, it is possible for a node to
send a message back to the node that created the message, in which case
the ParsedMessage.from_self field should actually be true.

This commit fixes that assumption by explicitly checking if the
message's signer ID matches the node's own ID.

Signed-off-by: Logan Seeley <seeley@bitwise.io>