### PR TITLE
Fix terminology for PBFT member nodes (was peers)

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -46,7 +46,7 @@ Fault Tolerance
 A PBFT network consists of nodes that are ordered from 0 to `n-1`, where
 `n` is the total number of nodes in the network. The
 :doc:`on-chain setting <on-chain-settings>` ``sawtooth.consensus.pbft.members``
-lists all nodes and determines the node order.
+lists all PBFT member nodes and determines the node order.
 
 The PBFT algorithm guarantees network `safety
 <https://en.wikipedia.org/wiki/Liveness#Liveness_and_safety>`__
@@ -105,7 +105,8 @@ Information Storage
 
 Each node stores several key pieces of information as part of its state:
 
-* List of nodes in the network (also called "connected peers")
+* List of PBFT member nodes in the network (from
+  ``sawtooth.consensus.pbft.members``)
 
 * Current view number, which identifies the primary node
 
@@ -138,9 +139,9 @@ For more information, see :doc:`on-chain-settings`.
 Consensus Messages
 ==================
 
-When a node receives a new consensus message from a peer, it checks the message
-type and creates the appropriate language-specific object for that type. All
-PBFT consensus messages are serialized as `protobufs (protocol buffers)
+When a node receives a new consensus message from a member node, it checks the
+message type and creates the appropriate language-specific object for that type.
+All PBFT consensus messages are serialized as `protobufs (protocol buffers)
 <https://developers.google.com/protocol-buffers/>`__.
 
 Generally, the message object must be verified to make sure that everything is

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -44,6 +44,10 @@ Glossary
   Block duration
     How many seconds to wait before trying to publish a block.
 
+  Member node
+    Sawtooth node that participates in PBFT consensus. Membership is controlled
+    by the on-chain setting ``sawtooth.consensus.pbft.members``.
+
   Message
     Block, with additional information (see `Message
     Types <message-types.html>`__).

--- a/docs/source/on-chain-settings.rst
+++ b/docs/source/on-chain-settings.rst
@@ -11,8 +11,9 @@ transaction family
 
 - ``sawtooth.consensus.pbft.members`` (required)
 
-  List of the member nodes in a Sawtooth PBFT network; a JSON-formatted string
-  of ``[<public-key-1>, <public-key-2>, ..., <public-key-n>]``.
+  List of the member nodes in a Sawtooth PBFT network, as a JSON-formatted
+  string with the format
+  ``[<public-key-1>, <public-key-2>, ..., <public-key-n>]``.
 
   ``sawtooth.consensus.pbft.members`` could look something like this in a
   four-node network:


### PR DESCRIPTION
Sawtooth already uses the term "peer" for static/dynamic peering, so the
PBFT doc was overloading this term. This PR changes "peer" to "(PBFT) member node"
and adds a glossary definition for "member node".

Note: The Sawtooth documentation will be fixed in a related-but-separate PR for
the hyperledger/sawtooth repo.

Signed-off-by: Anne Chenette <chenette@bitwise.io>