### PR TITLE
Enable restarting whole network with existing chain

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,6 +138,20 @@ pipeline {
             }
         }
 
+        stage('Run non-genesis startup tests') {
+            options {
+                timeout(time: 10, unit: 'MINUTES')
+            }
+            steps {
+                sh 'tests/test_non_genesis_startup.sh'
+            }
+            post {
+                always {
+                    sh 'docker run --rm -v $(pwd)/target:/target sawtooth-pbft-engine-local:${ISOLATION_ID} bash -c "chown -R ${JENKINS_UID} /target"'
+                }
+            }
+        }
+
         stage("Build Docs") {
             steps {
                 sh 'docker build . -f docs/Dockerfile -t sawtooth-pbft-docs:$ISOLATION_ID'

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -73,12 +73,7 @@ impl Engine for PbftEngine {
 
         let mut working_ticker = timing::Ticker::new(self.config.block_duration);
 
-        let mut node = PbftNode::new(
-            &self.config,
-            chain_head,
-            service,
-            pbft_state.read().is_primary(),
-        );
+        let mut node = PbftNode::new(&self.config, chain_head, service, &mut pbft_state.write());
 
         node.start_idle_timeout(&mut pbft_state.write());
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -50,7 +50,7 @@ impl Engine for PbftEngine {
 
         let StartupState {
             chain_head,
-            peers: _peers,
+            peers,
             local_peer_info,
         } = startup_state;
 
@@ -73,7 +73,13 @@ impl Engine for PbftEngine {
 
         let mut working_ticker = timing::Ticker::new(self.config.block_duration);
 
-        let mut node = PbftNode::new(&self.config, chain_head, service, &mut pbft_state.write());
+        let mut node = PbftNode::new(
+            &self.config,
+            chain_head,
+            peers,
+            service,
+            &mut pbft_state.write(),
+        );
 
         node.start_idle_timeout(&mut pbft_state.write());
 
@@ -170,6 +176,7 @@ fn handle_update(
         }
         Ok(Update::PeerConnected(info)) => {
             info!("Received PeerConnected message with peer info: {:?}", info);
+            node.on_peer_connected(info.peer_id, state)?
         }
         Ok(Update::PeerDisconnected(id)) => {
             info!("Received PeerDisconnected for peer ID: {:?}", id);

--- a/src/state.rs
+++ b/src/state.rs
@@ -20,7 +20,7 @@
 use std::fmt;
 use std::time::Duration;
 
-use sawtooth_sdk::consensus::engine::PeerId;
+use sawtooth_sdk::consensus::engine::{BlockId, PeerId};
 
 use crate::config::PbftConfig;
 use crate::error::PbftError;
@@ -92,6 +92,9 @@ pub struct PbftState {
     /// The current view
     pub view: u64,
 
+    /// The block ID of the node's current chain head
+    pub chain_head: BlockId,
+
     /// Current phase of the algorithm
     pub phase: PbftPhase,
 
@@ -149,6 +152,7 @@ impl PbftState {
             id,
             seq_num: head_block_num + 1,
             view: 0,
+            chain_head: BlockId::new(),
             phase: PbftPhase::PrePreparing,
             mode: PbftMode::Normal,
             f,


### PR DESCRIPTION
When the whole network is starting "fresh" from a non-genesis block,
none of the nodes will have the `Commit` messages necessary to build the
consensus seal for the last committed block (the chain head). To
bootstrap the network in this scenario, all nodes will send a `Commit`
message for their chain head in two cases:

1. When the node starts, if it is already connected to other peers, it
will broadcast the commits to those peers
2. Whenever one of the PBFT members connects

When > 2f + 1 nodes have connected and received these `Commit` messages,
the nodes will be able to build a seal using the messages.

This commit includes a shell script to verify the ability to restart a
network with an existing chain using the adhoc docker compose files.
Also adds this test to CI.

Signed-off-by: Logan Seeley <seeley@bitwise.io>