### PR TITLE
Rename on-chain peers list

### DIFF
--- a/adhoc/node.yaml
+++ b/adhoc/node.yaml
@@ -52,7 +52,7 @@ services:
           -k /shared_data/keys/settings.priv \
           sawtooth.consensus.algorithm.name=pbft \
           sawtooth.consensus.algorithm.version=0.1 \
-          sawtooth.consensus.pbft.peers=\\['\\\"'$$(cd /shared_data/validators && paste $$(ls -1) -d , | sed s/,/\\\\\\\",\\\\\\\"/g)'\\\"'\\]
+          sawtooth.consensus.pbft.members=\\['\\\"'$$(cd /shared_data/validators && paste $$(ls -1) -d , | sed s/,/\\\\\\\",\\\\\\\"/g)'\\\"'\\]
           -o config.batch && \
         sawadm genesis \
           config-genesis.batch config.batch && \

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -45,7 +45,7 @@ Fault Tolerance
 
 A PBFT network consists of nodes that are ordered from 0 to `n-1`, where
 `n` is the total number of nodes in the network. The
-:doc:`on-chain setting <on-chain-settings>` ``sawtooth.consensus.pbft.peers``
+:doc:`on-chain setting <on-chain-settings>` ``sawtooth.consensus.pbft.members``
 lists all nodes and determines the node order.
 
 The PBFT algorithm guarantees network `safety
@@ -70,7 +70,7 @@ A `view` is the period of time that a given node is the primary, so a `view
 change` means switching to a different primary node. The next primary is
 selected in a round-robin (circular) fashion, according to the order of nodes
 listed in the :doc:`on-chain setting <on-chain-settings>`
-``sawtooth.consensus.pbft.peers``.
+``sawtooth.consensus.pbft.members``.
 
 In a four-node network, for example, the first node (node 0) is the primary at
 view 0, the second node (node 1) is the primary at view 1, and so on.  When the
@@ -416,7 +416,7 @@ View changing mode has the following steps:
    operation.
 
 The next primary node is determined by the node ID, in sequential order, based
-on the order of nodes in the ``sawtooth.consensus.pbft.peers`` on-chain setting.
+on the order of nodes in the ``sawtooth.consensus.pbft.members`` on-chain setting.
 For more information, see :ref:`view-changes-choosing-primary-label`.
 
 

--- a/docs/source/installing-and-running-pbft.rst
+++ b/docs/source/installing-and-running-pbft.rst
@@ -78,7 +78,7 @@ be installed.
           ...
           sawset proposal create \
             ...
-            sawtooth.consensus.pbft.peers=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
+            sawtooth.consensus.pbft.members=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
             sawtooth.consensus.pbft.block_duration=100 \
             sawtooth.consensus.pbft.checkpoint_period=10 \
             sawtooth.consensus.pbft.view_change_timeout=4000 \

--- a/docs/source/on-chain-settings.rst
+++ b/docs/source/on-chain-settings.rst
@@ -9,12 +9,12 @@ transaction family
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/settings_transaction_family.html>`__:
 
 
-- ``sawtooth.consensus.pbft.peers`` (required)
+- ``sawtooth.consensus.pbft.members`` (required)
 
-  List of the peers in a Sawtooth PBFT network; a JSON-formatted string of
-  ``[<public-key-1>, <public-key-2>, ..., <public-key-n>]``.
+  List of the member nodes in a Sawtooth PBFT network; a JSON-formatted string
+  of ``[<public-key-1>, <public-key-2>, ..., <public-key-n>]``.
 
-  ``sawtooth.consensus.pbft.peers`` could look something like this in a
+  ``sawtooth.consensus.pbft.members`` could look something like this in a
   four-node network:
 
   .. code-block:: console

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,7 +91,7 @@ impl PbftConfig {
     /// Load configuration from on-chain Sawtooth settings.
     ///
     /// Configuration loads the following settings:
-    /// + `sawtooth.consensus.pbft.peers` (required)
+    /// + `sawtooth.consensus.pbft.members` (required)
     /// + `sawtooth.consensus.pbft.block_duration` (optional, default 200 ms)
     /// + `sawtooth.consensus.pbft.idle_timeout` (optional, default 30s)
     /// + `sawtooth.consensus.pbft.commit_timeout` (optional, default 30s)
@@ -103,7 +103,7 @@ impl PbftConfig {
     ///
     /// # Panics
     /// + If block duration is greater than the idle timeout
-    /// + If the `sawtooth.consensus.pbft.peers` setting is not provided or is invalid
+    /// + If the `sawtooth.consensus.pbft.members` setting is not provided or is invalid
     pub fn load_settings(&mut self, block_id: BlockId, service: &mut Service) {
         debug!("Getting on-chain settings for config");
         let settings: HashMap<String, String> = retry_until_ok(
@@ -113,7 +113,7 @@ impl PbftConfig {
                 service.get_settings(
                     block_id.clone(),
                     vec![
-                        String::from("sawtooth.consensus.pbft.peers"),
+                        String::from("sawtooth.consensus.pbft.members"),
                         String::from("sawtooth.consensus.pbft.block_duration"),
                         String::from("sawtooth.consensus.pbft.idle_timeout"),
                         String::from("sawtooth.consensus.pbft.commit_timeout"),
@@ -126,8 +126,8 @@ impl PbftConfig {
             },
         );
 
-        // Get the peers associated with this node (including ourselves). Panic if it is not provided;
-        // the network cannot function without this setting.
+        // Get the peers associated with this node (including ourselves). Panic if it is not
+        // provided; the network cannot function without this setting.
         let peers = get_peers_from_settings(&settings);
 
         self.peers = peers;
@@ -234,17 +234,17 @@ fn merge_millis_setting_if_set(
 /// Get the peers as a Vec<PeerId> from settings
 ///
 /// # Panics
-/// + If the `sawtooth.consenus.pbft.peers` setting is unset or invalid
+/// + If the `sawtooth.consenus.pbft.members` setting is unset or invalid
 pub fn get_peers_from_settings<S: std::hash::BuildHasher>(
     settings: &HashMap<String, String, S>,
 ) -> Vec<PeerId> {
     let peers_setting_value = settings
-        .get("sawtooth.consensus.pbft.peers")
-        .expect("'sawtooth.consensus.pbft.peers' is empty; this setting must exist to use PBFT");
+        .get("sawtooth.consensus.pbft.members")
+        .expect("'sawtooth.consensus.pbft.members' is empty; this setting must exist to use PBFT");
 
     let peers: Vec<String> = serde_json::from_str(peers_setting_value).unwrap_or_else(|err| {
         panic!(
-            "Unable to parse value at 'sawtooth.consensus.pbft.peers' due to error: {:?}",
+            "Unable to parse value at 'sawtooth.consensus.pbft.members' due to error: {:?}",
             err
         )
     });

--- a/src/node.rs
+++ b/src/node.rs
@@ -831,7 +831,7 @@ impl PbftNode {
     /// Check the on-chain list of peers; if it has changed, update peers list and return true.
     ///
     /// # Panics
-    /// + If the `sawtooth.consensus.pbft.peers` setting is unset or invalid
+    /// + If the `sawtooth.consensus.pbft.members` setting is unset or invalid
     /// + If the network this node is on does not have enough nodes to be Byzantine fault tolernant
     fn update_membership(&mut self, block_id: BlockId, state: &mut PbftState) {
         // Get list of peers from settings (retry until a valid result is received)
@@ -842,7 +842,7 @@ impl PbftNode {
             || {
                 self.service.get_settings(
                     block_id.clone(),
-                    vec![String::from("sawtooth.consensus.pbft.peers")],
+                    vec![String::from("sawtooth.consensus.pbft.members")],
                 )
             },
         );
@@ -1187,7 +1187,7 @@ impl PbftNode {
     /// Verify the given consenus seal
     ///
     /// # Panics
-    /// + If the `sawtooth.consensus.pbft.peers` setting is unset or invalid
+    /// + If the `sawtooth.consensus.pbft.members` setting is unset or invalid
     fn verify_consensus_seal(
         &mut self,
         seal: &PbftSeal,
@@ -1242,7 +1242,7 @@ impl PbftNode {
             || {
                 self.service.get_settings(
                     previous_id.clone(),
-                    vec![String::from("sawtooth.consensus.pbft.peers")],
+                    vec![String::from("sawtooth.consensus.pbft.members")],
                 )
             },
         );
@@ -1540,7 +1540,7 @@ mod tests {
             // Set the default settings
             let mut default_settings = HashMap::new();
             default_settings.insert(
-                "sawtooth.consensus.pbft.peers".to_string(),
+                "sawtooth.consensus.pbft.members".to_string(),
                 serde_json::to_string(&peers).unwrap(),
             );
             service
@@ -2149,7 +2149,7 @@ mod tests {
         // Set the MockService to return a different peers list for block_id=[1]
         let mut block_1_settings = HashMap::new();
         block_1_settings.insert(
-            "sawtooth.consensus.pbft.peers".to_string(),
+            "sawtooth.consensus.pbft.members".to_string(),
             serde_json::to_string(
                 &vec![
                     key_pairs[0].pub_key.clone(),
@@ -3625,7 +3625,7 @@ mod tests {
     /// existing member malfunctioning.
     ///
     /// Membership changes in Sawtooth PBFT are dictated by the on-chain setting
-    /// `sawtooth.consensus.pbft.peers`, which contains a list of the network’s peers. When this
+    /// `sawtooth.consensus.pbft.members`, which contains a list of the network’s peers. When this
     /// on-chain setting is updated in a block and that block gets committed, the PBFT nodes must
     /// update their local lists of members and value of `f` (the maximum number of faulty nodes)
     /// to match the changes.
@@ -3655,7 +3655,7 @@ mod tests {
             vec![6],
         ];
         block_1_settings.insert(
-            "sawtooth.consensus.pbft.peers".to_string(),
+            "sawtooth.consensus.pbft.members".to_string(),
             serde_json::to_string(&block_1_peers.iter().map(hex::encode).collect::<Vec<_>>())
                 .unwrap(),
         );
@@ -3674,7 +3674,7 @@ mod tests {
             vec![6],
         ];
         block_2_settings.insert(
-            "sawtooth.consensus.pbft.peers".to_string(),
+            "sawtooth.consensus.pbft.members".to_string(),
             serde_json::to_string(&block_2_peers.iter().map(hex::encode).collect::<Vec<_>>())
                 .unwrap(),
         );
@@ -3684,7 +3684,7 @@ mod tests {
             .insert(vec![2], block_2_settings);
         let mut block_3_settings = HashMap::new();
         block_3_settings.insert(
-            "sawtooth.consensus.pbft.peers".to_string(),
+            "sawtooth.consensus.pbft.members".to_string(),
             serde_json::to_string(
                 &vec![vec![0], vec![1], vec![2]]
                     .iter()

--- a/tests/client.yaml
+++ b/tests/client.yaml
@@ -43,7 +43,7 @@ services:
           -k /etc/sawtooth/keys/validator.priv \
           sawtooth.consensus.algorithm.name=pbft \
           sawtooth.consensus.algorithm.version=0.1 \
-          sawtooth.consensus.pbft.peers=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
+          sawtooth.consensus.pbft.members=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
           sawtooth.consensus.pbft.block_duration=100 \
           sawtooth.consensus.pbft.view_change_timeout=4000 \
           sawtooth.consensus.pbft.message_timeout=10 \

--- a/tests/grafana.yaml
+++ b/tests/grafana.yaml
@@ -69,7 +69,7 @@ services:
           -k /etc/sawtooth/keys/validator.priv \
           sawtooth.consensus.algorithm.name=pbft \
           sawtooth.consensus.algorithm.version=0.1 \
-          sawtooth.consensus.pbft.peers=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
+          sawtooth.consensus.pbft.members=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
           sawtooth.consensus.pbft.block_duration=100 \
           sawtooth.consensus.pbft.view_change_timeout=4000 \
           sawtooth.consensus.pbft.message_timeout=10 \

--- a/tests/test_dynamic_membership.sh
+++ b/tests/test_dynamic_membership.sh
@@ -111,17 +111,17 @@ docker exec -e API=${INIT_APIS[0]} $ADMIN bash -c '\
   NEW_PEERS=$(cd /shared_data/validators && paste $(ls -1) -d , \
     | sed s/,/\\\",\\\"/g); \
   SETTING_PEERS=($(sawtooth settings list --url "http://$API:8008" \
-    --filter "sawtooth.consensus.pbft.peers" --format csv | sed -n 2p | \
+    --filter "sawtooth.consensus.pbft.members" --format csv | sed -n 2p | \
     sed "s/\"\",\"\"/\ /g")); \
   until [[ "${#SETTING_PEERS[@]}" -eq 5 ]]; do \
-    echo "Attempting to set sawtooth.consensus.pbft.peers..."; \
+    echo "Attempting to set sawtooth.consensus.pbft.members..."; \
     # Try to update setting \
     sawset proposal create -k /shared_data/keys/settings.priv \
-      --url "http://$API:8008" sawtooth.consensus.pbft.peers=[\"$NEW_PEERS\"]; \
+      --url "http://$API:8008" sawtooth.consensus.pbft.members=[\"$NEW_PEERS\"]; \
     # Wait and see if setting has been updated \
     sleep 5; \
     SETTING_PEERS=($(sawtooth settings list --url "http://$API:8008" \
-      --filter "sawtooth.consensus.pbft.peers" --format csv | sed -n 2p | \
+      --filter "sawtooth.consensus.pbft.members" --format csv | sed -n 2p | \
       sed "s/\"\",\"\"/\ /g")); \
   done;'
 
@@ -186,17 +186,17 @@ docker exec -e API=${INIT_APIS[0]} $ADMIN bash -c '\
   NEW_PEERS=$(cd /shared_data/validators && paste $(ls -1) -d , \
     | sed s/,/\\\",\\\"/g); \
   SETTING_PEERS=($(sawtooth settings list --url "http://$API:8008" \
-    --filter "sawtooth.consensus.pbft.peers" --format csv | sed -n 2p | \
+    --filter "sawtooth.consensus.pbft.members" --format csv | sed -n 2p | \
     sed "s/\"\",\"\"/\ /g")); \
   until [[ "${#SETTING_PEERS[@]}" -eq 6 ]]; do \
-    echo "Attempting to set sawtooth.consensus.pbft.peers..."; \
+    echo "Attempting to set sawtooth.consensus.pbft.members..."; \
     # Try to update setting \
     sawset proposal create -k /shared_data/keys/settings.priv \
-      --url "http://$API:8008" sawtooth.consensus.pbft.peers=[\"$NEW_PEERS\"]; \
+      --url "http://$API:8008" sawtooth.consensus.pbft.members=[\"$NEW_PEERS\"]; \
     # Wait and see if setting has been updated \
     sleep 5; \
     SETTING_PEERS=($(sawtooth settings list --url "http://$API:8008" \
-      --filter "sawtooth.consensus.pbft.peers" --format csv | sed -n 2p | \
+      --filter "sawtooth.consensus.pbft.members" --format csv | sed -n 2p | \
       sed "s/\"\",\"\"/\ /g")); \
   done;'
 
@@ -237,17 +237,17 @@ docker exec -e API=${INIT_APIS[0]} $ADMIN bash -c '\
   NEW_PEERS=$(cd /shared_data/validators && paste $(ls -1 | head -5) -d , \
     | sed s/,/\\\",\\\"/g); \
   SETTING_PEERS=($(sawtooth settings list --url "http://$API:8008" \
-    --filter "sawtooth.consensus.pbft.peers" --format csv | sed -n 2p | \
+    --filter "sawtooth.consensus.pbft.members" --format csv | sed -n 2p | \
     sed "s/\"\",\"\"/\ /g")); \
   until [[ "${#SETTING_PEERS[@]}" -eq 6 ]]; do \
-    echo "Attempting to set sawtooth.consensus.pbft.peers..."; \
+    echo "Attempting to set sawtooth.consensus.pbft.members..."; \
     # Try to update setting \
     sawset proposal create -k /shared_data/keys/settings.priv \
-      --url "http://$API:8008" sawtooth.consensus.pbft.peers=[\"$NEW_PEERS\"]; \
+      --url "http://$API:8008" sawtooth.consensus.pbft.members=[\"$NEW_PEERS\"]; \
     # Wait and see if setting has been updated \
     sleep 5; \
     SETTING_PEERS=($(sawtooth settings list --url "http://$API:8008" \
-      --filter "sawtooth.consensus.pbft.peers" --format csv | sed -n 2p | \
+      --filter "sawtooth.consensus.pbft.members" --format csv | sed -n 2p | \
       sed "s/\"\",\"\"/\ /g")); \
   done;'
 

--- a/tests/test_liveness.yaml
+++ b/tests/test_liveness.yaml
@@ -72,7 +72,7 @@ services:
           -k /etc/sawtooth/keys/validator.priv \
           sawtooth.consensus.algorithm.name=pbft \
           sawtooth.consensus.algorithm.version=0.1 \
-          sawtooth.consensus.pbft.peers=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
+          sawtooth.consensus.pbft.members=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
           sawtooth.consensus.pbft.block_duration=100 \
           sawtooth.consensus.pbft.view_change_timeout=4000 \
           sawtooth.consensus.pbft.message_timeout=10 \


### PR DESCRIPTION
Rename the on-chain list of PBFT nodes from
`sawtooth.conensus.pbft.peers` to `sawtooth.consensus.pbft.members`.
This is to reduce confusion when using the term "peer" to refer to nodes
that may not be an accepted PBFT member based on the on-chain setting.

Signed-off-by: Logan Seeley <seeley@bitwise.io>