### PR TITLE
Errors resulting from messages are warnings

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -202,6 +202,12 @@ pub fn test_handle_update(
 
 fn log_any_error(res: Result<(), PbftError>) {
     if let Err(e) = res {
-        error!("{}", e)
+        // Treat errors that result from other nodes' messages as warnings
+        match e {
+            PbftError::SigningError(_)
+            | PbftError::FaultyPrimary(_)
+            | PbftError::InvalidMessage(_) => warn!("{}", e),
+            _ => error!("{}", e),
+        }
     }
 }


### PR DESCRIPTION
Errors that are the result of handling messages from other nodes
(`SigningError`s, `FaultyPrimary`s, and `InvalidMessage`s) should be
treated as warnings since they indicate a problem with other nodes, not
errors in the typical sense.

Signed-off-by: Logan Seeley <seeley@bitwise.io>