### PR TITLE
Correct view change timeout start time

### DIFF
--- a/src/timing.rs
+++ b/src/timing.rs
@@ -98,7 +98,6 @@ impl Timeout {
         self.duration
     }
 
-    #[cfg(test)]
     pub fn is_active(&self) -> bool {
         self.state == TimeoutState::Active
     }


### PR DESCRIPTION
Updates the view change timeout to start only when 2f + 1 `ViewChange`
messages are received for a view. Previously, the timeout was started
when a view change was started by a node, but this is not the correct
behavior according to the PBFT paper.

Signed-off-by: Logan Seeley <seeley@bitwise.io>