### PR TITLE
Fix references to block publishing delay

### DIFF
--- a/docs/source/configuring-pbft.rst
+++ b/docs/source/configuring-pbft.rst
@@ -95,7 +95,7 @@ transaction processor <https://sawtooth.hyperledger.org/docs/core/releases/lates
   | (Optional; default 30000 ms)
   | How long to wait for the next ``BlockNew`` and ``PrePrepare`` messages
   | before determining that the primary node is faulty. The idle timeout must be
-  | longer than the block duration.
+  | longer than the block publishing delay.
 
 - | ``sawtooth.consensus.pbft.members``
   | (Required)

--- a/docs/source/configuring-pbft.rst
+++ b/docs/source/configuring-pbft.rst
@@ -84,8 +84,8 @@ transaction processor <https://sawtooth.hyperledger.org/docs/core/releases/lates
 
 - | ``sawtooth.consensus.pbft.commit_timeout``
   | (Optional; default 10000 ms)
-  | How long to wait between block commits before determining that the primary
-  | node is faulty.
+  | How long to wait (after Pre-Preparing) for the node to commit the block
+  | before determining that the primary node is faulty.
 
 - | ``sawtooth.consensus.pbft.forced_view_change_interval``
   | (Optional; default 100 blocks)

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -41,8 +41,8 @@ Glossary
   Consensus seal
     Proof that a block underwent consensus.
 
-  Block duration
-    How many seconds to wait before trying to publish a block.
+  Block publishing delay
+    How many milliseconds to wait before trying to publish a block.
 
   Member node
     Sawtooth node that participates in PBFT consensus. Membership is controlled

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,7 +99,7 @@ impl PbftConfig {
     /// + `sawtooth.consensus.pbft.forced_view_change_interval` (optional, default 100 blocks)
     ///
     /// # Panics
-    /// + If block duration is greater than the idle timeout
+    /// + If block publishing delay is greater than the idle timeout
     /// + If the `sawtooth.consensus.pbft.members` setting is not provided or is invalid
     pub fn load_settings(&mut self, block_id: BlockId, service: &mut Service) {
         debug!("Getting on-chain settings for config");

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -99,7 +99,7 @@ impl Engine for PbftEngine {
                 Err(err) => log_any_error(Err(err)),
             }
 
-            // If the block duration has passed, attempt to publish a block
+            // If the block publishing delay has passed, attempt to publish a block
             block_publishing_ticker.tick(|| log_any_error(node.try_publish(state)));
 
             // If the idle timeout has expired, initiate a view change


### PR DESCRIPTION
When the block_duration was renamed to block_publishing_delay, some
references to the variable in documentation and comments got missed.
This commit fixes those.

Also updates definition of commit timeout