### PR TITLE
Add PBFT to Architecture title in doc

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -1,5 +1,5 @@
-Architecture
-************
+PBFT Architecture
+*****************
 
 The Sawtooth PBFT algorithm is a voting-based consensus algorithm with Byzantine
 fault tolerance, which ensures `safety and liveness


### PR DESCRIPTION
The Sawtooth core docs now link directly to the PBFT architecture section.
This change provides necessary context for a user coming from the core docs.

Signed-off-by: Anne Chenette <chenette@bitwise.io>