### PR TITLE
Fix (clarify) PBFT engine name

### DIFF
--- a/docs/source/using-pbft-consensus.rst
+++ b/docs/source/using-pbft-consensus.rst
@@ -11,8 +11,11 @@ restricted membership. It has the following requirements:
 * A PBFT network must be fully peered; that is, all nodes must be directly
   connected to all other nodes. Static peering is recommended.
 
-* Each node on the network must install and run the PBFT consensus engine,
-  ``sawtooth-pbft-engine``.
+* Each node on the network must install and run the PBFT consensus engine.
+
+  - Package: ``sawtooth-pbft-engine``
+  - Executable: ``pbft-engine``
+  - Service: ``sawtooth-pbft-engine.service``
 
 * Each node must run the Settings transaction processor (or an equivalent) to
   handle the PBFT and Sawtooth on-chain settings.


### PR DESCRIPTION
This PR lists all names of the PBFT consensus engine: package, executable,
and service. (The existing doc shows only the package name.)

Signed-off-by: Anne Chenette <chenette@bitwise.io>