### PR TITLE
Add info on finding PBFT consensus name + version

### DIFF
--- a/docs/source/using-pbft-consensus.rst
+++ b/docs/source/using-pbft-consensus.rst
@@ -36,12 +36,11 @@ restricted membership. It has the following requirements:
   list all PBFT member nodes in the network. For more information, see
   :ref:`on-chain-settings-label`.
 
-See the Hyperledger Sawtooth documentation for information on using PBFT
-consensus:
+For the procedure to configure PBFT, see the Hyperledger Sawtooth documentation:
 
 * Developers: `Creating a Sawtooth
   Network <https://sawtooth.hyperledger.org/docs/core/releases/latest/app_developers_guide/creating_sawtooth_network.html>`__
-  shows how to create a test network with PBFT consensus for your application
+  shows how to create a test network with PBFT consensus for an application
   development environment.
 
 * Sawtooth administrators: `Setting Up a Sawtooth

--- a/docs/source/using-pbft-consensus.rst
+++ b/docs/source/using-pbft-consensus.rst
@@ -24,6 +24,14 @@ restricted membership. It has the following requirements:
   using the on-chain settings ``sawtooth.consensus.algorithm.name`` and
   ``sawtooth.consensus.algorithm.version``.
 
+  - The PBFT consensus engine name is ``pbft``.
+
+  - The version number is in the file ``sawtooth-pbft/Cargo.toml`` (see the
+    `sawtooth-pbft <https://github.com/hyperledger/sawtooth-pbft/>`_ repository)
+    as ``version = "{major}.{minor}.{patch}"``. Use only the first two digits
+    (major and minor release numbers); omit the patch number.  For example, if
+    the version is 1.0.3, use ``1.0`` for the version setting.
+
 * The on-chain configuration setting ``sawtooth.consensus.pbft.members`` must
   list all PBFT member nodes in the network. For more information, see
   :ref:`on-chain-settings-label`.


### PR DESCRIPTION
 - Expand the genesis block (on-chain settings) item to say that the name is pbft and the version can be found in Cargo.toml.

- Add links to the Sawtooth core procedures in the App Dev Guide and Sys Admin Guide.

- Also clean up wording for the text that links to the full config procedures in the Sawtooth core docs.