### PR TITLE
Doc: Update PBFT glossary

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -37,8 +37,8 @@ Glossary
     node is either a :term:`primary node` or a :term:`secondary node`.
 
   Message
-    Block with additional consensus-related information (see
-    :ref:`pbft-arch-message-types`).
+    Consensus-related information that nodes send to each other. For more
+    information, see :ref:`consensus-messages-label`.
 
   Node
     Virtual or physical machine running all the components necessary for a

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -4,10 +4,9 @@ Glossary
 .. glossary::
 
   Node
-    Machine running all the components necessary for a working blockchain
-    (including the Validator, the REST API, at least one transaction processor,
-    and the PBFT algorithm itself). In this RFC, unless otherwise specified,
-    it can be assumed that *Node* refers to the PBFT component of the machine.
+    Virtual or physical machine running all the components necessary for a
+    working Sawtooth blockchain: a validator, an optional REST API, at least
+    one transaction processor, and the PBFT consensus engine.
 
     The `original PBFT paper <http://pmg.csail.mit.edu/papers/osdi99.pdf>`__
     uses the terms `server` or `replica` instead of `node`.
@@ -18,37 +17,47 @@ Glossary
     consensus API.
 
   Block
-    A part of the
-    `blockchain <https://en.wikipedia.org/wiki/Block chain>`__,
-    containing some operations and a link to the previous block.
+    Part of the `blockchain <https://en.wikipedia.org/wiki/Block chain>`__
+    that contains one or more operations (called `transactions`) and a link to
+    the previous block.
 
-  Primary
-    Node in charge of making the final consensus decisions and committing to
-    the blockchain.  Additionally is responsible for publishing the blocks given
-    to it by the Consensus API, and starting the consensus process.
+  Primary node
+    Node that directs the consensus process for the network. (The other nodes
+    in the network participate as secondary nodes.) The primary node creates
+    each block and publishes it to the network, then starts the consensus
+    process for the block.
 
-  Secondaries
-    Auxiliary nodes used for consensus.
+  Secondary node
+    Auxiliary node used for consensus. A Sawtooth network using PBFT consensus
+    has one :term:`primary node`; all other nodes are secondary nodes.
+
+    The `original PBFT paper <http://pmg.csail.mit.edu/papers/osdi99.pdf>`__
+    uses the term `backup` instead of `secondary node`.
 
   Client
     Machine that sends requests to and receives replies from the network of
-    nodes. PBFT has no direct interaction with clients; the Validator bundles
-    all client requests into blocks and sends them through the Consensus API to
-    the consensus algorithm.
+    Sawtooth nodes. PBFT has no direct interaction with clients; the validator
+    bundles all client requests into blocks and sends them through the
+    consensus API to the consensus engine.
 
   Consensus seal
-    Proof that a block underwent consensus.
+    Proof that a block went through consensus.
+
+  Leader
+    See :term:`primary node`.
 
   Member node
     Sawtooth node that participates in PBFT consensus. Membership is controlled
-    by the on-chain setting ``sawtooth.consensus.pbft.members``.
+    by the on-chain setting ``sawtooth.consensus.pbft.members``. Each member
+    node is either a :term:`primary node` or a :term:`secondary node`.
 
   Message
-    Block, with additional information (see :ref:`pbft-arch-message-types`).
+    Block with additional consensus-related information (see
+    :ref:`pbft-arch-message-types`).
 
   Working block
-    The block that has been initialized but not finalized, and is currently
-    being committed to.
+    Sawtooth block that has been initialized (but not finalized) and is
+    currently being evaluated to determine if it can be committed.
 
   View
     The period of time when the current primary node is in charge. The
@@ -72,7 +81,8 @@ Glossary
     Sawtooth component that validates transactions and updates state based on
     rules defined by the associated `transaction family`. (These rules specify
     the business logic, also called a `smart contract`, for the transaction
-    processor.) For more information, see the `Hyperledger Sawtooth
+    processor.) For more information, see `"Transaction Family Specifications"
+    in the Hyperledger Sawtooth
     documentation <https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications.html>`__.
 
   Working block

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -9,11 +9,8 @@ Glossary
     and the PBFT algorithm itself). In this RFC, unless otherwise specified,
     it can be assumed that *Node* refers to the PBFT component of the machine.
 
-  Server
-    Synonym for node.
-
-  Replica
-    Synonym for node.
+    The `original PBFT paper <http://pmg.csail.mit.edu/papers/osdi99.pdf>`__
+    uses the terms `server` or `replica` instead of `node`.
 
   Validator
     Component of a node responsible for interactions with the blockchain.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -60,18 +60,6 @@ Glossary
     changes when the primary is deemed faulty (see
     :ref:`view-changes-choosing-primary-label`).
 
-  :math:`n`
-    The total number of nodes in the network.
-
-  :math:`f`
-    The maximum number of faulty nodes.
-
-  :math:`v`
-    The current view number (how many primary node changes have occurred).
-
-  :math:`p`
-    The primary server number; :math:`p = v \mod n`.
-
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -81,10 +81,6 @@ Glossary
     primary node is deemed faulty. For more information, see
     :ref:`view-changes-choosing-primary-label`).
 
-  Working block
-    Sawtooth block that has been initialized (but not finalized) and is
-    currently being evaluated to determine if it can be committed.
-
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -41,9 +41,6 @@ Glossary
   Consensus seal
     Proof that a block underwent consensus.
 
-  Block publishing delay
-    How many milliseconds to wait before trying to publish a block.
-
   Member node
     Sawtooth node that participates in PBFT consensus. Membership is controlled
     by the on-chain setting ``sawtooth.consensus.pbft.members``.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -79,7 +79,7 @@ Glossary
     view changes at regular intervals (controlled by the on-chain setting
     ``sawtooth.consensus.pbft.forced_view_change_interval``), and when the
     primary node is deemed faulty. For more information, see
-    :ref:`view-changes-choosing-primary-label`).
+    :ref:`view-changes-choosing-primary-label`.
 
 
 .. Licensed under Creative Commons Attribution 4.0 International License

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -57,6 +57,24 @@ Glossary
     changes when the primary is deemed faulty (see
     :ref:`view-changes-choosing-primary-label`).
 
+  Consensus API
+    Sawtooth component that abstracts consensus-related interactions between
+    the validator and a consensus engine. The consensus API allows `dynamic
+    consensus`, a feature that allows a choice of consensus for a Sawtooth
+    network.
+
+  Consensus engine
+    Component that provides consensus functionality for a Sawtooth
+    network. The consensus engine communicates with the validator through
+    the consensus API.
+
+  Transaction processor
+    Sawtooth component that validates transactions and updates state based on
+    rules defined by the associated `transaction family`. (These rules specify
+    the business logic, also called a `smart contract`, for the transaction
+    processor.) For more information, see the `Hyperledger Sawtooth
+    documentation <https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications.html>`__.
+
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -3,42 +3,27 @@ Glossary
 
 .. glossary::
 
-  Node
-    Virtual or physical machine running all the components necessary for a
-    working Sawtooth blockchain: a validator, an optional REST API, at least
-    one transaction processor, and the PBFT consensus engine.
-
-    The `original PBFT paper <http://pmg.csail.mit.edu/papers/osdi99.pdf>`__
-    uses the terms `server` or `replica` instead of `node`.
-
-  Validator
-    Sawtooth component that is responsible for interactions with the
-    blockchain. The validator interacts with the consensus engine through the
-    consensus API.
-
   Block
     Part of the `blockchain <https://en.wikipedia.org/wiki/Block chain>`__
     that contains one or more operations (called `transactions`) and a link to
     the previous block.
-
-  Primary node
-    Node that directs the consensus process for the network. (The other nodes
-    in the network participate as secondary nodes.) The primary node creates
-    each block and publishes it to the network, then starts the consensus
-    process for the block.
-
-  Secondary node
-    Auxiliary node used for consensus. A Sawtooth network using PBFT consensus
-    has one :term:`primary node`; all other nodes are secondary nodes.
-
-    The `original PBFT paper <http://pmg.csail.mit.edu/papers/osdi99.pdf>`__
-    uses the term `backup` instead of `secondary node`.
 
   Client
     Machine that sends requests to and receives replies from the network of
     Sawtooth nodes. PBFT has no direct interaction with clients; the validator
     bundles all client requests into blocks and sends them through the
     consensus API to the consensus engine.
+
+  Consensus API
+    Sawtooth component that abstracts consensus-related interactions between
+    the validator and a consensus engine. The consensus API allows `dynamic
+    consensus`, a feature that allows a choice of consensus for a Sawtooth
+    network.
+
+  Consensus engine
+    Component that provides consensus functionality for a Sawtooth
+    network. The consensus engine communicates with the validator through
+    the consensus API.
 
   Consensus seal
     Proof that a block went through consensus.
@@ -55,27 +40,26 @@ Glossary
     Block with additional consensus-related information (see
     :ref:`pbft-arch-message-types`).
 
-  Working block
-    Sawtooth block that has been initialized (but not finalized) and is
-    currently being evaluated to determine if it can be committed.
+  Node
+    Virtual or physical machine running all the components necessary for a
+    working Sawtooth blockchain: a validator, an optional REST API, at least
+    one transaction processor, and the PBFT consensus engine.
 
-  View
-    The period of time when the current primary node is in charge. The
-    view changes at regular intervals (controlled by the on-chain setting
-    ``sawtooth.consensus.pbft.forced_view_change_interval``), and when the
-    primary node is deemed faulty. For more information, see
-    :ref:`view-changes-choosing-primary-label`).
+    The `original PBFT paper <http://pmg.csail.mit.edu/papers/osdi99.pdf>`__
+    uses the terms `server` or `replica` instead of `node`.
 
-  Consensus API
-    Sawtooth component that abstracts consensus-related interactions between
-    the validator and a consensus engine. The consensus API allows `dynamic
-    consensus`, a feature that allows a choice of consensus for a Sawtooth
-    network.
+  Primary node
+    Node that directs the consensus process for the network. (The other nodes
+    in the network participate as secondary nodes.) The primary node creates
+    each block and publishes it to the network, then starts the consensus
+    process for the block.
 
-  Consensus engine
-    Component that provides consensus functionality for a Sawtooth
-    network. The consensus engine communicates with the validator through
-    the consensus API.
+  Secondary node
+    Auxiliary node used for consensus. A Sawtooth network using PBFT consensus
+    has one :term:`primary node`; all other nodes are secondary nodes.
+
+    The `original PBFT paper <http://pmg.csail.mit.edu/papers/osdi99.pdf>`__
+    uses the term `backup` instead of `secondary node`.
 
   Transaction processor
     Sawtooth component that validates transactions and updates state based on
@@ -84,6 +68,18 @@ Glossary
     processor.) For more information, see `"Transaction Family Specifications"
     in the Hyperledger Sawtooth
     documentation <https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications.html>`__.
+
+  Validator
+    Sawtooth component that is responsible for interactions with the
+    blockchain. The validator interacts with the consensus engine through the
+    consensus API.
+
+  View
+    The period of time when the current primary node is in charge. The
+    view changes at regular intervals (controlled by the on-chain setting
+    ``sawtooth.consensus.pbft.forced_view_change_interval``), and when the
+    primary node is deemed faulty. For more information, see
+    :ref:`view-changes-choosing-primary-label`).
 
   Working block
     Sawtooth block that has been initialized (but not finalized) and is

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -13,8 +13,9 @@ Glossary
     uses the terms `server` or `replica` instead of `node`.
 
   Validator
-    Component of a node responsible for interactions with the blockchain.
-    Interactions with the validator are abstracted by the Consensus API.
+    Sawtooth component that is responsible for interactions with the
+    blockchain. The validator interacts with the consensus engine through the
+    consensus API.
 
   Block
     A part of the
@@ -50,8 +51,10 @@ Glossary
     being committed to.
 
   View
-    The period of time of PBFT when the current primary is in charge. The view
-    changes when the primary is deemed faulty (see
+    The period of time when the current primary node is in charge. The
+    view changes at regular intervals (controlled by the on-chain setting
+    ``sawtooth.consensus.pbft.forced_view_change_interval``), and when the
+    primary node is deemed faulty. For more information, see
     :ref:`view-changes-choosing-primary-label`).
 
   Consensus API
@@ -71,6 +74,10 @@ Glossary
     the business logic, also called a `smart contract`, for the transaction
     processor.) For more information, see the `Hyperledger Sawtooth
     documentation <https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications.html>`__.
+
+  Working block
+    Sawtooth block that has been initialized (but not finalized) and is
+    currently being evaluated to determine if it can be committed.
 
 
 .. Licensed under Creative Commons Attribution 4.0 International License


### PR DESCRIPTION
This PR contains separate commits for the following changes:

- Remove math terms, because f, n, p, and v are adequately defined in the "Architecture" section.

- Remove entry for Block duration.

- Add three new terms: Consensus API, Consensus engine, Transaction family.

- Remove entries for Replica and Server; replace with a sentence under Node.

- Update View entry with info about regular view changes.

- Edit definitions to clarify and fix grammar. This commit also changes "Primary" to "Primary node" 
  (ditto "Secondary node") and mentions the original PBFT paper's terms for primary and secondary.

- Alphabetize entries (in a separate commit with no technical or wording changes).

- Update Message definition (corrected and removed "block", because a message isn't a block).

- Delete Working block entry (term is no longer used).