### PR TITLE
 Retire Inactive Maintainers 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @vaporos @agunde406 @bridger-herman @aludvik @jsmitchell @ltseeley
+*       @agunde406 @jsmitchell @ltseeley @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,9 +1,16 @@
-| Name           | GitHub         | RocketChat    |
-| -------------- | -------------- | ------------- |
-| Shawn Amundson | vaporos        | amundson      |
-| Andi Gunderson | agunde406      | agunde        |
+## Maintainers
+
+### Active Maintainers
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Andi Gunderson | agunde406 | agunde |
+| James Mitchell | jsmitchell | jsmitchell |
+| Logan Seeley   | ltseeley | ltseeley |
+| Shawn Amundson | vaporos | amundson |
+
+### Retired Maintainers
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Adam Ludvik | aludvik | adamludvik |
 | Bridger Herman | bridger-herman | bridgerherman |
-| Adam Ludvik    | aludvik        | adamludvik    |
-| James Mitchell | jsmitchell     | jsmitchell    |
-| Logan Seeley   | ltseeley       | ltseeley      |
-| Kenneth Koski  | knkski         | knkski        |
+| Kenneth Koski | knkski | knkski |


### PR DESCRIPTION
The following maintainers have asked to be retired:
Adam Ludvik, Bridger Herman, and and Kenneth Koski.

As described in the Sawtooth Governance RFC changes to maintainers must be approved unanimously by the current group of maintainers.