### PR TITLE
Propose new maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @jsmitchell @ltseeley @vaporos
+*       @agunde406 @chenette @jsmitchell @ltseeley @peterschwarz @rberg2 @rbuysse @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,8 +4,12 @@
 | Name | GitHub | RocketChat |
 | --- | --- | --- |
 | Andi Gunderson | agunde406 | agunde |
+| Anne Chenette | chenette | achenette |
 | James Mitchell | jsmitchell | jsmitchell |
 | Logan Seeley   | ltseeley | ltseeley |
+| Peter Schwarz | peterschwarz | pschwarz |
+| Richard Berg | rberg2 | rberg2 |
+| Ryan Beck-Buysse | rbuysse | rbuysse |
 | Shawn Amundson | vaporos | amundson |
 
 ### Retired Maintainers


### PR DESCRIPTION
Add Anne Chenette, Peter Schwarz, Richard Berg and
Ryan Beck-Buysse to maintainers.

As described in the Sawtooth Governance RFC changes to maintainers must be approved unanimously by the current group of maintainers.