### PR TITLE
Check blocks and handle BlockValid/BlockInvalid

### DIFF
--- a/adhoc/node.yaml
+++ b/adhoc/node.yaml
@@ -52,7 +52,8 @@ services:
           -k /shared_data/keys/settings.priv \
           sawtooth.consensus.algorithm.name=pbft \
           sawtooth.consensus.algorithm.version=1.0 \
-          sawtooth.consensus.pbft.members=\\['\\\"'$$(cd /shared_data/validators && paste $$(ls -1) -d , | sed s/,/\\\\\\\",\\\\\\\"/g)'\\\"'\\]
+          sawtooth.consensus.pbft.members=\\['\\\"'$$(cd /shared_data/validators && paste $$(ls -1) -d , | sed s/,/\\\\\\\",\\\\\\\"/g)'\\\"'\\] \
+          sawtooth.gossip.time_to_live=1 \
           -o config.batch && \
         sawadm genesis \
           config-genesis.batch config.batch && \

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,7 +101,7 @@ impl PbftConfig {
     /// # Panics
     /// + If block publishing delay is greater than the idle timeout
     /// + If the `sawtooth.consensus.pbft.members` setting is not provided or is invalid
-    pub fn load_settings(&mut self, block_id: BlockId, service: &mut Service) {
+    pub fn load_settings(&mut self, block_id: BlockId, service: &mut dyn Service) {
         debug!("Getting on-chain settings for config");
         let settings: HashMap<String, String> = retry_until_ok(
             self.exponential_retry_base,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -146,9 +146,8 @@ fn handle_update(
 ) -> Result<bool, PbftError> {
     match incoming_message {
         Ok(Update::BlockNew(block)) => node.on_block_new(block, state)?,
-        Ok(Update::BlockValid(_)) | Ok(Update::BlockInvalid(_)) => {
-            info!("Received BlockValid or BlockInvalid message; ignoring");
-        }
+        Ok(Update::BlockValid(block_id)) => node.on_block_valid(block_id, state)?,
+        Ok(Update::BlockInvalid(block_id)) => node.on_block_invalid(block_id)?,
         Ok(Update::BlockCommit(block_id)) => node.on_block_commit(block_id, state)?,
         Ok(Update::PeerMessage(message, _)) => {
             // Since the signer ID in the PeerMessageHeader is verified by the validator, it can be

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -43,7 +43,7 @@ impl Engine for PbftEngine {
     fn start(
         &mut self,
         updates: Receiver<Update>,
-        mut service: Box<Service>,
+        mut service: Box<dyn Service>,
         startup_state: StartupState,
     ) -> Result<(), Error> {
         info!("Startup state received from validator: {:?}", startup_state);

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -126,6 +126,13 @@ impl PbftLog {
             .find(|block| block.block_id.as_slice() == block_id)
     }
 
+    /// Get the `Block` with the specified block ID from `unvalidated_blocks`.
+    pub fn get_unvalidated_block_with_id(&self, block_id: &[u8]) -> Option<&Block> {
+        self.unvalidated_blocks
+            .get(block_id)
+            .map(|(block, _)| block)
+    }
+
     /// Add a parsed PBFT message to the log
     pub fn add_message(&mut self, msg: ParsedMessage) {
         trace!("Adding message to log: {:?}", msg);
@@ -251,6 +258,8 @@ mod tests {
     /// Blocks are retrieved using the following methods:
     /// - `get_block_with_id` will get the block that matches the specified block ID
     /// - `get_blocks_with_num` will get all blocks that have the specified block number
+    /// - `get_unvalidated_block_with_id` will get the unvalidated block that matches the specified
+    ///   block ID
     ///
     /// This test will verify that blocks can be added to a `PbftLog` using block adding methods,
     /// that blocks are properly marked as valid or dropped, and that the methods for retrieving
@@ -266,7 +275,9 @@ mod tests {
         log.add_unvalidated_block(block1.clone(), PbftSeal::new());
 
         // Verify the block is stored as unvalidated
-        assert!(log.unvalidated_blocks.get(&block1.block_id).is_some());
+        assert!(log
+            .get_unvalidated_block_with_id(&block1.block_id)
+            .is_some());
         assert!(log.blocks.is_empty());
 
         // Validate block, then verify that the block is returned and the block is marked as valid

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -19,19 +19,23 @@
 
 #![allow(unknown_lints)]
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 use hex;
-use sawtooth_sdk::consensus::engine::Block;
+use sawtooth_sdk::consensus::engine::{Block, BlockId};
 
 use crate::config::PbftConfig;
 use crate::message_type::{ParsedMessage, PbftMessageType};
-use crate::protos::pbft_message::PbftMessageInfo;
+use crate::protos::pbft_message::{PbftMessageInfo, PbftSeal};
 
 /// Struct for storing messages that a PbftNode receives
 pub struct PbftLog {
-    /// All blocks received from the validator that have not been garbage collected
+    /// All blocks received from the validator that have not been validated yet
+    unvalidated_blocks: HashMap<BlockId, (Block, PbftSeal)>,
+
+    /// All blocks received from the validator that have been validated and not yet garbage
+    /// collected
     blocks: HashSet<Block>,
 
     /// All messages accepted by the node that have not been garbage collected
@@ -69,16 +73,42 @@ impl PbftLog {
     /// Create a new, empty `PbftLog` with the `max_log_size` specified in the `config`
     pub fn new(config: &PbftConfig) -> Self {
         PbftLog {
+            unvalidated_blocks: HashMap::new(),
             blocks: HashSet::new(),
             messages: HashSet::new(),
             max_log_size: config.max_log_size,
         }
     }
 
-    /// Add a `Block` to the log
-    pub fn add_block(&mut self, block: Block) {
-        trace!("Adding block to log: {:?}", block);
+    /// Add an already validated `Block` to the log
+    pub fn add_validated_block(&mut self, block: Block) {
+        trace!("Adding validated block to log: {:?}", block);
         self.blocks.insert(block);
+    }
+
+    /// Add an unvalidated `Block` and its `PbftSeal` to the log
+    pub fn add_unvalidated_block(&mut self, block: Block, seal: PbftSeal) {
+        trace!("Adding unvalidated block to log: {:?}", block);
+        self.unvalidated_blocks
+            .insert(block.block_id.clone(), (block, seal));
+    }
+
+    /// Move the `Block` corresponding to `block_id` from `unvalidated_blocks` to `blocks`. Return
+    /// the block itself to be used by the calling code.
+    pub fn block_validated(&mut self, block_id: BlockId) -> Option<(Block, PbftSeal)> {
+        trace!("Marking block as validated: {:?}", block_id);
+        self.unvalidated_blocks
+            .remove(&block_id)
+            .map(|(block, seal)| {
+                self.blocks.insert(block.clone());
+                (block, seal)
+            })
+    }
+
+    /// Drop the `Block` corresponding to `block_id` from `unvalidated_blocks`.
+    pub fn block_invalidated(&mut self, block_id: BlockId) -> bool {
+        trace!("Dropping invalidated block: {:?}", block_id);
+        self.unvalidated_blocks.remove(&block_id).is_some()
     }
 
     /// Get all `Block`s in the message log with the specified block number
@@ -210,22 +240,43 @@ mod tests {
     /// The `PbftLog` must reliably store and retrieve blocks for the node to keep track of the
     /// blocks it receives from the validator, perform consensus on them, and commit or fail them.
     ///
-    /// All blocks are added to the `PbftLog` using the `add_block` method, and they are retrieved
-    /// using the following methods:
+    /// Blocks are usually added to the `PbftLog` using the `add_unvalidated_block` method, then
+    /// later marked as valid using the `block_validated` method or dropped using the
+    /// `block_invalidated` method. These blocks cannot be retrieved from the log until they are
+    /// marked as valid.
+    ///
+    /// Blocks may also be added to the log using the `add_validated_block` method; in this case,
+    /// the block can be retrived immediately without marking it as valid.
+    ///
+    /// Blocks are retrieved using the following methods:
     /// - `get_block_with_id` will get the block that matches the specified block ID
     /// - `get_blocks_with_num` will get all blocks that have the specified block number
     ///
-    /// This test will verify that blocks can be added to a `PbftLog` using its `add_block` method
-    /// and that the methods for retrieving blocks work as intended.
+    /// This test will verify that blocks can be added to a `PbftLog` using block adding methods,
+    /// that blocks are properly marked as valid or dropped, and that the methods for retrieving
+    /// blocks work as intended.
     #[test]
     fn test_block_logging() {
         // Initialize an empty log
         let cfg = mock_config(4);
         let mut log = PbftLog::new(&cfg);
 
-        // Add block 1 to the log
+        // Add block 1 (unvalidated) to the log
         let block1 = mock_block(1);
-        log.add_block(block1.clone());
+        log.add_unvalidated_block(block1.clone(), PbftSeal::new());
+
+        // Verify the block is stored as unvalidated
+        assert!(log.unvalidated_blocks.get(&block1.block_id).is_some());
+        assert!(log.blocks.is_empty());
+
+        // Validate block, then verify that the block is returned and the block is marked as valid
+        // in the log
+        let (block, _) = log
+            .block_validated(block1.block_id.clone())
+            .expect("Block was not in log");
+        assert_eq!(block, block1);
+        assert!(log.unvalidated_blocks.is_empty());
+        assert!(log.blocks.get(&block1).is_some());
 
         // Verify log correctly retrieves blocks by ID
         assert_eq!(
@@ -235,12 +286,18 @@ mod tests {
         );
         assert!(log.get_block_with_id(&vec![2]).is_none());
 
-        // Add more blocks
+        // Add an (already validated) block to the log
         let mut block2 = mock_block(2);
         block2.block_num = 1;
-        log.add_block(block2.clone());
+        log.add_validated_block(block2.clone());
+
+        // Verify adding an already validated block works
+        assert!(log.unvalidated_blocks.is_empty());
+        assert!(log.blocks.get(&block2).is_some());
+
+        // Add a 3rd block to the log
         let block3 = mock_block(3);
-        log.add_block(block3.clone());
+        log.add_validated_block(block3.clone());
 
         // Verify log correctly retrieves blocks by number
         let blocks_with_num_1 = log.get_blocks_with_num(1);

--- a/src/node.rs
+++ b/src/node.rs
@@ -42,7 +42,7 @@ use crate::timing::{retry_until_ok, Timeout};
 /// Contains the core logic of the PBFT node
 pub struct PbftNode {
     /// Used for interactions with the validator
-    pub service: Box<Service>,
+    pub service: Box<dyn Service>,
 
     /// Log of messages this node has received and accepted
     pub msg_log: PbftLog,
@@ -56,7 +56,7 @@ impl PbftNode {
         config: &PbftConfig,
         chain_head: Block,
         connected_peers: Vec<PeerInfo>,
-        service: Box<Service>,
+        service: Box<dyn Service>,
         state: &mut PbftState,
     ) -> Self {
         let mut n = PbftNode {

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -161,11 +161,11 @@ impl<T: fmt::Display + Serialize + DeserializeOwned> fmt::Display for DiskStorag
 impl<T: Serialize + DeserializeOwned> Storage for DiskStorage<T> {
     type S = T;
 
-    fn read<'a>(&'a self) -> Box<StorageReadGuard<'a, T, Target = T> + 'a> {
+    fn read<'a>(&'a self) -> Box<dyn StorageReadGuard<'a, T, Target = T> + 'a> {
         Box::new(DiskStorageReadGuard::new(self))
     }
 
-    fn write<'a>(&'a mut self) -> Box<StorageWriteGuard<'a, T, Target = T> + 'a> {
+    fn write<'a>(&'a mut self) -> Box<dyn StorageWriteGuard<'a, T, Target = T> + 'a> {
         Box::new(DiskStorageWriteGuard::new(self))
     }
 }

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -123,11 +123,11 @@ impl<T: Serialize + DeserializeOwned + fmt::Display> fmt::Display for MemStorage
 impl<T: Serialize + DeserializeOwned> Storage for MemStorage<T> {
     type S = T;
 
-    fn read<'a>(&'a self) -> Box<StorageReadGuard<'a, T, Target = T> + 'a> {
+    fn read<'a>(&'a self) -> Box<dyn StorageReadGuard<'a, T, Target = T> + 'a> {
         Box::new(MemStorageReadGuard::new(self))
     }
 
-    fn write<'a>(&'a mut self) -> Box<StorageWriteGuard<'a, T, Target = T> + 'a> {
+    fn write<'a>(&'a mut self) -> Box<dyn StorageWriteGuard<'a, T, Target = T> + 'a> {
         Box::new(MemStorageWriteGuard::new(self))
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -51,8 +51,8 @@ pub trait StorageWriteGuard<'a, T: Sized>: DerefMut<Target = T> {}
 pub trait Storage {
     type S;
 
-    fn read<'a>(&'a self) -> Box<StorageReadGuard<'a, Self::S, Target = Self::S> + 'a>;
-    fn write<'a>(&'a mut self) -> Box<StorageWriteGuard<'a, Self::S, Target = Self::S> + 'a>;
+    fn read<'a>(&'a self) -> Box<dyn StorageReadGuard<'a, Self::S, Target = Self::S> + 'a>;
+    fn write<'a>(&'a mut self) -> Box<dyn StorageWriteGuard<'a, Self::S, Target = Self::S> + 'a>;
 }
 
 /// Given a location string, returns the appropriate storage
@@ -63,7 +63,7 @@ pub fn get_storage<'a, T: Sized + Serialize + DeserializeOwned + 'a, F: Fn() -> 
     default: F,
 ) -> Result<Box<dyn Storage<S = T> + 'a>, String> {
     if location == "memory" {
-        Ok(Box::new(MemStorage::new(default)) as Box<Storage<S = T>>)
+        Ok(Box::new(MemStorage::new(default)) as Box<dyn Storage<S = T>>)
     } else if location.starts_with("disk") {
         let split = location.splitn(2, '+').collect::<Vec<_>>();
 
@@ -93,7 +93,7 @@ mod tests {
     }
 
     // You can also pass in the storages themselves
-    fn add_storages(foo: &mut (Storage<S = u32>), bar: &mut (Storage<S = u32>)) {
+    fn add_storages(foo: &mut dyn (Storage<S = u32>), bar: &mut dyn (Storage<S = u32>)) {
         **foo.write() += **bar.read();
     }
 


### PR DESCRIPTION
Updates PBFT to check blocks that it receives the validator and handle
the resulting BlockValid and BlockInvalid messages. This change is
necessary due to the Sawtooth validator being updated to validate blocks
only when specifically requested by consensus.

Overall changes made to PBFT:
- When PBFT receives a block and does its verification, it calls
`service.check_blocks` to validate the block and adds the block to the
log as an unvalidated block.
- BlockInvalid messages are handled by a new `on_block_invalid` method.
This method drops the block from the log and fails it.
- BlockValid messages are handled by a new `on_block_valid` method. This
method marks the block as valid in the log then processes the block as
usual (sends a PrePrepare, catches up, etc.).

Changes made to the log:
- Log has a new HashMap that stores unvalidated blocks along with their
corresponding seals.
- The `add_block` method is split into two methods:
`add_validated_block` which is used to add blocks that have already been
validated (such as chain head on startup) and `add_unvalidated_block`
which is used to add blocks that have not yet been validated (when
received as a BlockNew).
- `block_validated` and `block_invalidated` methods are added to move a
block from `unvalidated_blocks` to `blocks` or drop a block,
respectively.

Signed-off-by: Logan Seeley <seeley@bitwise.io>