### PR TITLE
Fix seal verification

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -68,7 +68,7 @@ pub fn get_storage<'a, T: Sized + Serialize + DeserializeOwned + 'a, F: Fn() -> 
         let split = location.splitn(2, '+').collect::<Vec<_>>();
 
         if split.len() != 2 {
-            Err(format!("Invalid location: {}", location))?
+            return Err(format!("Invalid location: {}", location));
         }
 
         Ok(Box::new(DiskStorage::from_path(split[1], default).unwrap()))


### PR DESCRIPTION
Fixes a bug where the requested settings for a block's grandparent block do not exist when verifying the block's consensus seal.