### PR TITLE
Fix missing command line arg assignments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,9 @@ fn main() {
     if let Some(timeout) = args.update_recv_timeout {
         pbft_config.update_recv_timeout = Duration::from_millis(timeout);
     }
+    if let Some(storage) = args.storage_location {
+        pbft_config.storage_location = storage;
+    }
 
     let pbft_engine = engine::PbftEngine::new(pbft_config);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,9 @@ fn main() {
     if let Some(storage) = args.storage_location {
         pbft_config.storage_location = storage;
     }
+    if let Some(max_log_size) = args.max_log_size {
+        pbft_config.max_log_size = max_log_size;
+    }
 
     let pbft_engine = engine::PbftEngine::new(pbft_config);
 


### PR DESCRIPTION
Currently, even though the max-log-size and storage location arguments are parsed in the arguments, the values are never actually assigned to the created PbftConfig.  This resolves that so that the command works as advertised.