### PR TITLE
Trap on SIGTERM in test scripts

### DIFF
--- a/tests/test_crash_fault_tolerance.sh
+++ b/tests/test_crash_fault_tolerance.sh
@@ -52,7 +52,7 @@ function cleanup {
     docker-compose -p ${ISOLATION_ID} -f adhoc/admin.yaml down --remove-orphans --volumes
 }
 
-trap cleanup EXIT
+trap cleanup EXIT SIGTERM
 
 echo "Ensuring sawtooth services are built"
 docker-compose -p ${ISOLATION_ID} -f tests/sawtooth-services.yaml build

--- a/tests/test_dynamic_membership.sh
+++ b/tests/test_dynamic_membership.sh
@@ -55,7 +55,7 @@ function cleanup {
     docker-compose -p ${ISOLATION_ID} -f adhoc/admin.yaml down --remove-orphans --volumes
 }
 
-trap cleanup EXIT
+trap cleanup EXIT SIGTERM
 
 echo "Ensuring sawtooth services are built"
 docker-compose -p ${ISOLATION_ID} -f tests/sawtooth-services.yaml build

--- a/tests/test_non_genesis_startup.sh
+++ b/tests/test_non_genesis_startup.sh
@@ -49,7 +49,7 @@ function cleanup {
     docker-compose -p ${ISOLATION_ID} -f adhoc/admin.yaml down --remove-orphans --volumes
 }
 
-trap cleanup EXIT
+trap cleanup EXIT SIGTERM
 
 echo "Ensuring sawtooth services are built"
 docker-compose -p ${ISOLATION_ID} -f tests/sawtooth-services.yaml build


### PR DESCRIPTION
Updates the test scripts to trap on SIGTERM as well as EXIT to clean up
the docker containers and dump the logs. This changes ensures that the
cleanup and log dumping happens when Jenkins aborts one of the scripts,
which will aid in troubleshooting issues.

Signed-off-by: Logan Seeley <seeley@bitwise.io>