### PR TITLE
Fix clippy::bind_instead_of_map

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -1305,7 +1305,7 @@ impl PbftNode {
                         }
                         Ok(())
                     })
-                    .and_then(|id| Ok(ids.insert(id)))?;
+                    .map(|id| ids.insert(id))?;
                     Ok(ids)
                 })?;
 
@@ -1440,7 +1440,7 @@ impl PbftNode {
                         }
                         Ok(())
                     })
-                    .and_then(|id| Ok(ids.insert(id)))?;
+                    .map(|id| ids.insert(id))?;
                     Ok(ids)
                 })?;
 


### PR DESCRIPTION
This change fixes the "bind_instead_of_map" Clippy error where an `and_then` call is used but only returns `Ok`.  This can be replaced with `map`, which doesn't require wrapping the result in a `Result`.
