### PR TITLE
Pin PBFT liveness tests to 1-3 nightly validator

### DIFF
--- a/tests/sawtooth-pbft-test.dockerfile
+++ b/tests/sawtooth-pbft-test.dockerfile
@@ -19,7 +19,7 @@ FROM ubuntu:bionic
 RUN apt-get update \
   && apt-get install gnupg -y
 
-RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/droptarget/nightly bionic universe" >> /etc/apt/sources.list \
  && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
  || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
  && apt-get update \
@@ -35,10 +35,10 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic univers
     python3-sawtooth-cli \
     python3-sawtooth-intkey \
     python3-sawtooth-rest-api \
-    python3-sawtooth-settings \
     python3-sawtooth-validator \
     python3-requests \
     python3-nose2 \
+    sawtooth-settings-tp \
     sawtooth-smallbank-workload \
     sawtooth-intkey-workload \
     sawtooth-smallbank-tp-go \


### PR DESCRIPTION
sawtooth-core is currently working toward 2.0 and may not
be compatibly with this current version of PBFT. For now
the liveness test will continue to be run against 1-3,
the "main" branch for further 1.x develpment.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>