### PR TITLE
Fix needless_borrow lint

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -31,7 +31,7 @@ pub fn hash_sha512(bytes: &[u8]) -> Vec<u8> {
 
 /// Verifies that the SHA-512 hash of the given content matches the given hash
 pub fn verify_sha512(content: &[u8], content_hash: &[u8]) -> Result<(), PbftError> {
-    let computed_sha512 = hash_sha512(&content);
+    let computed_sha512 = hash_sha512(content);
 
     if computed_sha512 != content_hash {
         Err(PbftError::SigningError(format!(

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -46,11 +46,8 @@ pub struct PbftLog {
 
 impl fmt::Display for PbftLog {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let msg_infos: Vec<PbftMessageInfo> = self
-            .messages
-            .iter()
-            .map(|ref msg| msg.info().clone())
-            .collect();
+        let msg_infos: Vec<PbftMessageInfo> =
+            self.messages.iter().map(|msg| msg.info().clone()).collect();
         let string_infos: Vec<String> = msg_infos
             .iter()
             .map(|info: &PbftMessageInfo| -> String {

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -174,9 +174,9 @@ impl ParsedMessage {
 
     pub fn info(&self) -> &PbftMessageInfo {
         match &self.message {
-            PbftMessageWrapper::Message(m) => &m.get_info(),
-            PbftMessageWrapper::NewView(m) => &m.get_info(),
-            PbftMessageWrapper::Seal(m) => &m.get_info(),
+            PbftMessageWrapper::Message(m) => m.get_info(),
+            PbftMessageWrapper::NewView(m) => m.get_info(),
+            PbftMessageWrapper::Seal(m) => m.get_info(),
         }
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -572,7 +572,7 @@ impl PbftNode {
         }
 
         // Catch up
-        self.catchup(state, &seal, false)
+        self.catchup(state, seal, false)
     }
 
     /// Handle a `BlockNew` update from the Validator
@@ -1178,12 +1178,12 @@ impl PbftNode {
         F: Fn(&PbftMessage) -> Result<(), PbftError>,
     {
         // Parse the message
-        let pbft_message: PbftMessage = Message::parse_from_bytes(&vote.get_message_bytes())
+        let pbft_message: PbftMessage = Message::parse_from_bytes(vote.get_message_bytes())
             .map_err(|err| {
                 PbftError::SerializationError("Error parsing PbftMessage from vote".into(), err)
             })?;
-        let header: ConsensusPeerMessageHeader =
-            Message::parse_from_bytes(&vote.get_header_bytes()).map_err(|err| {
+        let header: ConsensusPeerMessageHeader = Message::parse_from_bytes(vote.get_header_bytes())
+            .map_err(|err| {
                 PbftError::SerializationError("Error parsing header from vote".into(), err)
             })?;
 


### PR DESCRIPTION
This change fixes a lint introduced with the Rust 1.54.0 release. The lint warns of borrowing an already borrowed value.

See https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow for more detail.
