### PR TITLE
Fix derive_partial_eq_without_eq Clippy error

### DIFF
--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -230,7 +230,7 @@ impl ParsedMessage {
 }
 
 // Messages related to PBFT consensus
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
 pub enum PbftMessageType {
     /// Basic message types for the multicast protocol
     PrePrepare,

--- a/src/state.rs
+++ b/src/state.rs
@@ -27,7 +27,7 @@ use crate::error::PbftError;
 use crate::timing::Timeout;
 
 /// Phases of the PBFT algorithm, in `Normal` mode
-#[derive(Debug, PartialEq, PartialOrd, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Serialize, Deserialize)]
 pub enum PbftPhase {
     PrePreparing,
     Preparing,
@@ -52,7 +52,7 @@ impl fmt::Display for PbftPhase {
 }
 
 /// Modes that the PBFT algorithm can possibly be in
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum PbftMode {
     Normal,
     /// Contains the view number of the view this node is attempting to change to


### PR DESCRIPTION
Fixes a clippy error introduced in Rust 1.63

If a type T derives PartialEq and all of its members implement
Eq, then T can always implement Eq. Implementing Eq allows T to be
used in APIs that require Eq types. It also allows structs
containing T to derive Eq themselves.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>